### PR TITLE
refactor!: rename EsbConfig to RadioConfig

### DIFF
--- a/.config/.readthedocs.yaml
+++ b/.config/.readthedocs.yaml
@@ -22,6 +22,8 @@ build:
       - yarn install
       - yarn build:debug
       - yarn docs
+    pre_install:
+      - python -m pip install -U pip
 
 mkdocs:
   configuration: docs/mkdocs.yml

--- a/bindings/node/src/config.rs
+++ b/bindings/node/src/config.rs
@@ -1,6 +1,5 @@
 #![cfg(target_os = "linux")]
 use crate::types::{coerce_to_bool, CrcLength, DataRate, PaLevel};
-use rf24::radio::EsbConfig;
 
 use napi::{bindgen_prelude::Buffer, JsNumber, Result};
 
@@ -8,7 +7,7 @@ use napi::{bindgen_prelude::Buffer, JsNumber, Result};
 #[napi]
 #[derive(Debug, Clone, Copy)]
 pub struct RadioConfig {
-    inner: EsbConfig,
+    inner: rf24::radio::RadioConfig,
     _addr_buf: [u8; 5],
 }
 
@@ -53,7 +52,7 @@ impl RadioConfig {
     #[napi(constructor)]
     pub fn new() -> Self {
         Self {
-            inner: EsbConfig::default(),
+            inner: rf24::radio::RadioConfig::default(),
             _addr_buf: [0u8; 5],
         }
     }
@@ -375,11 +374,11 @@ impl RadioConfig {
 }
 
 impl RadioConfig {
-    pub fn into_inner(&self) -> EsbConfig {
+    pub fn into_inner(&self) -> rf24::radio::RadioConfig {
         self.inner.clone()
     }
 
-    pub fn from_inner(config: EsbConfig) -> Self {
+    pub fn from_inner(config: rf24::radio::RadioConfig) -> Self {
         Self {
             inner: config,
             _addr_buf: [0u8; 5],

--- a/bindings/python/src/config.rs
+++ b/bindings/python/src/config.rs
@@ -1,7 +1,6 @@
 #![cfg(target_os = "linux")]
 use crate::types::{CrcLength, DataRate, PaLevel};
 use pyo3::prelude::*;
-use rf24::radio::EsbConfig;
 
 use std::borrow::Cow;
 
@@ -44,7 +43,7 @@ use std::borrow::Cow;
 #[pyclass(module = "rf24_py")]
 #[derive(Debug, Clone, Copy)]
 pub struct RadioConfig {
-    inner: EsbConfig,
+    inner: rf24::radio::RadioConfig,
     _addr_buf: [u8; 5],
 }
 
@@ -53,7 +52,7 @@ impl RadioConfig {
     #[new]
     pub fn new() -> Self {
         Self {
-            inner: EsbConfig::default(),
+            inner: rf24::radio::RadioConfig::default(),
             _addr_buf: [0u8; 5],
         }
     }
@@ -333,11 +332,11 @@ impl RadioConfig {
 }
 
 impl RadioConfig {
-    pub fn into_inner(&self) -> EsbConfig {
+    pub fn into_inner(&self) -> rf24::radio::RadioConfig {
         self.inner.clone()
     }
 
-    pub fn from_inner(config: EsbConfig) -> Self {
+    pub fn from_inner(config: rf24::radio::RadioConfig) -> Self {
         Self {
             inner: config,
             _addr_buf: [0u8; 5],

--- a/crates/rf24-rs/src/radio/config.rs
+++ b/crates/rf24-rs/src/radio/config.rs
@@ -88,13 +88,13 @@ impl EsbPipeConfig {
 /// An object to configure the radio.
 ///
 /// This struct follows a builder pattern. Since all fields are private, users should
-/// start with the [`EsbConfig::default`] constructor, then mutate the object accordingly.
+/// start with the [`RadioConfig::default`] constructor, then mutate the object accordingly.
 /// ```
 /// let mut config = Config::default();
 /// config = config.with_channel(42);
 /// ```
 #[derive(Debug, Clone, Copy)]
-pub struct EsbConfig {
+pub struct RadioConfig {
     pub(crate) config_reg: Config,
     pub(crate) auto_retries: SetupRetry,
     pub(crate) setup_rf_aw: SetupRfAw,
@@ -105,29 +105,29 @@ pub struct EsbConfig {
     pipes: EsbPipeConfig,
 }
 
-impl Default for EsbConfig {
-    /// Instantiate a [`EsbConfig`] object with library defaults.
+impl Default for RadioConfig {
+    /// Instantiate a [`RadioConfig`] object with library defaults.
     ///
     /// | feature | default value |
     /// |--------:|:--------------|
-    /// | [`EsbConfig::channel()`] | `76` |
-    /// | [`EsbConfig::address_length()`] | `5` |
-    /// | [`EsbConfig::pa_level()`] | [`PaLevel::Max`] |
-    /// | [`EsbConfig::lna_enable()`] | `true` |
-    /// | [`EsbConfig::crc_length()`] | [`CrcLength::Bit16`] |
-    /// | [`EsbConfig::data_rate()`] | [`DataRate::Mbps1`] |
-    /// | [`EsbConfig::payload_length()`] | `32` |
-    /// | [`EsbConfig::dynamic_payloads()`] | `false` |
-    /// | [`EsbConfig::auto_ack()`] | `0x3F` (enabled for pipes 0 - 5) |
-    /// | [`EsbConfig::ack_payloads()`] | `false` |
-    /// | [`EsbConfig::ask_no_ack()`] | `false` |
-    /// | [`EsbConfig::auto_retry_delay()`] | `5` |
-    /// | [`EsbConfig::auto_retry_count()`] | `15` |
-    /// | [`EsbConfig::tx_address()`] | `[0xE7; 5]` |
-    /// | [`EsbConfig::rx_address()`] | See below table about [Default RX addresses](#default-rx-pipes-configuration) |
-    /// | [`EsbConfig::rx_dr()`] | `true` |
-    /// | [`EsbConfig::tx_ds()`] | `true` |
-    /// | [`EsbConfig::tx_df()`] | `true` |
+    /// | [`RadioConfig::channel()`] | `76` |
+    /// | [`RadioConfig::address_length()`] | `5` |
+    /// | [`RadioConfig::pa_level()`] | [`PaLevel::Max`] |
+    /// | [`RadioConfig::lna_enable()`] | `true` |
+    /// | [`RadioConfig::crc_length()`] | [`CrcLength::Bit16`] |
+    /// | [`RadioConfig::data_rate()`] | [`DataRate::Mbps1`] |
+    /// | [`RadioConfig::payload_length()`] | `32` |
+    /// | [`RadioConfig::dynamic_payloads()`] | `false` |
+    /// | [`RadioConfig::auto_ack()`] | `0x3F` (enabled for pipes 0 - 5) |
+    /// | [`RadioConfig::ack_payloads()`] | `false` |
+    /// | [`RadioConfig::ask_no_ack()`] | `false` |
+    /// | [`RadioConfig::auto_retry_delay()`] | `5` |
+    /// | [`RadioConfig::auto_retry_count()`] | `15` |
+    /// | [`RadioConfig::tx_address()`] | `[0xE7; 5]` |
+    /// | [`RadioConfig::rx_address()`] | See below table about [Default RX addresses](#default-rx-pipes-configuration) |
+    /// | [`RadioConfig::rx_dr()`] | `true` |
+    /// | [`RadioConfig::tx_ds()`] | `true` |
+    /// | [`RadioConfig::tx_df()`] | `true` |
     ///
     /// ## Default RX pipes' configuration
     ///
@@ -178,8 +178,8 @@ impl Default for EsbConfig {
     }
 }
 
-impl EsbConfig {
-    /// Returns the value set by [`EsbConfig::with_crc_length()`].
+impl RadioConfig {
+    /// Returns the value set by [`RadioConfig::with_crc_length()`].
     pub const fn crc_length(&self) -> CrcLength {
         self.config_reg.crc_length()
     }
@@ -195,7 +195,7 @@ impl EsbConfig {
         }
     }
 
-    /// Returns the value set by [`EsbConfig::with_data_rate()`].
+    /// Returns the value set by [`RadioConfig::with_data_rate()`].
     pub const fn data_rate(&self) -> DataRate {
         self.setup_rf_aw.data_rate()
     }
@@ -211,7 +211,7 @@ impl EsbConfig {
         }
     }
 
-    /// Returns the value set by [`EsbConfig::with_pa_level()`].
+    /// Returns the value set by [`RadioConfig::with_pa_level()`].
     pub const fn pa_level(&self) -> PaLevel {
         self.setup_rf_aw.pa_level()
     }
@@ -227,7 +227,7 @@ impl EsbConfig {
         }
     }
 
-    /// Returns the value set by [`EsbConfig::with_lna_enable()`].
+    /// Returns the value set by [`RadioConfig::with_lna_enable()`].
     pub const fn lna_enable(&self) -> bool {
         self.setup_rf_aw.lna_enable()
     }
@@ -244,7 +244,7 @@ impl EsbConfig {
         }
     }
 
-    /// Returns the value set by [`EsbConfig::with_address_length()`].
+    /// Returns the value set by [`RadioConfig::with_address_length()`].
     pub const fn address_length(&self) -> u8 {
         self.setup_rf_aw.address_length()
     }
@@ -260,7 +260,7 @@ impl EsbConfig {
         }
     }
 
-    /// Returns the value set by [`EsbConfig::with_channel()`].
+    /// Returns the value set by [`RadioConfig::with_channel()`].
     pub const fn channel(&self) -> u8 {
         self.channel
     }
@@ -279,12 +279,12 @@ impl EsbConfig {
         }
     }
 
-    /// The auto-retry feature's `delay` (set via [`EsbConfig::with_auto_retries()`])
+    /// The auto-retry feature's `delay` (set via [`RadioConfig::with_auto_retries()`])
     pub const fn auto_retry_delay(&self) -> u8 {
         self.auto_retries.ard()
     }
 
-    /// The auto-retry feature's `count` (set via [`EsbConfig::with_auto_retries()`])
+    /// The auto-retry feature's `count` (set via [`RadioConfig::with_auto_retries()`])
     pub const fn auto_retry_count(&self) -> u8 {
         self.auto_retries.arc()
     }
@@ -303,7 +303,7 @@ impl EsbConfig {
         }
     }
 
-    /// Get the value set by [`EsbConfig::rx_dr()`].
+    /// Get the value set by [`RadioConfig::rx_dr()`].
     pub const fn rx_dr(&self) -> bool {
         self.config_reg.rx_dr()
     }
@@ -319,7 +319,7 @@ impl EsbConfig {
         }
     }
 
-    /// Get the value set by [`EsbConfig::tx_ds()`].
+    /// Get the value set by [`RadioConfig::tx_ds()`].
     pub const fn tx_ds(&self) -> bool {
         self.config_reg.tx_ds()
     }
@@ -335,7 +335,7 @@ impl EsbConfig {
         }
     }
 
-    /// Get the value set by [`EsbConfig::tx_df()`].
+    /// Get the value set by [`RadioConfig::tx_df()`].
     pub const fn tx_df(&self) -> bool {
         self.config_reg.tx_df()
     }
@@ -351,7 +351,7 @@ impl EsbConfig {
         }
     }
 
-    /// Return the value set by [`EsbConfig::with_ask_no_ack()`].
+    /// Return the value set by [`RadioConfig::with_ask_no_ack()`].
     pub const fn ask_no_ack(&self) -> bool {
         self.feature.ask_no_ack()
     }
@@ -369,17 +369,17 @@ impl EsbConfig {
         }
     }
 
-    /// Return the value set by [`EsbConfig::with_dynamic_payloads()`].
+    /// Return the value set by [`RadioConfig::with_dynamic_payloads()`].
     ///
     /// This feature is enabled automatically when enabling ACK payloads
-    /// via [`EsbConfig::with_ack_payloads()`].
+    /// via [`RadioConfig::with_ack_payloads()`].
     pub const fn dynamic_payloads(&self) -> bool {
         self.feature.dynamic_payloads()
     }
 
     /// Enable or disable dynamically sized payloads.
     ///
-    /// Enabling this feature nullifies the utility of [`EsbConfig::payload_length()`].
+    /// Enabling this feature nullifies the utility of [`RadioConfig::payload_length()`].
     pub fn with_dynamic_payloads(self, enable: bool) -> Self {
         let new_config = self.feature.with_dynamic_payloads(enable);
         Self {
@@ -388,7 +388,7 @@ impl EsbConfig {
         }
     }
 
-    /// Return the value set by [`EsbConfig::with_auto_ack()`].
+    /// Return the value set by [`RadioConfig::with_auto_ack()`].
     pub const fn auto_ack(&self) -> u8 {
         self.auto_ack
     }
@@ -400,7 +400,7 @@ impl EsbConfig {
     ///
     /// To enable the feature for pipes 0, 1 and 4:
     /// ```
-    /// let config = EsbConfig::default().with_auto_ack(0b010011);
+    /// let config = RadioConfig::default().with_auto_ack(0b010011);
     /// ```
     /// If enabling the feature for any pipe other than 0, then the pipe 0 should also have the
     /// feature enabled because pipe 0 is used to transmit automatic ACK packets in RX mode.
@@ -411,14 +411,14 @@ impl EsbConfig {
         }
     }
 
-    /// Return the value set by [`EsbConfig::with_ack_payloads()`].
+    /// Return the value set by [`RadioConfig::with_ack_payloads()`].
     pub const fn ack_payloads(&self) -> bool {
         self.feature.ack_payloads()
     }
 
     /// Enable or disable custom ACK payloads for auto-ACK packets.
     ///
-    /// ACK payloads require the [`EsbConfig::auto_ack`] and [`EsbConfig::dynamic_payloads`]
+    /// ACK payloads require the [`RadioConfig::auto_ack`] and [`RadioConfig::dynamic_payloads`]
     /// to be enabled. If ACK payloads are enabled, then this function also enables those
     /// features (for all pipes).
     pub fn with_ack_payloads(self, enable: bool) -> Self {
@@ -431,7 +431,7 @@ impl EsbConfig {
         }
     }
 
-    /// Return the value set by [`EsbConfig::with_payload_length()`].
+    /// Return the value set by [`RadioConfig::with_payload_length()`].
     ///
     /// The hardware's maximum payload length is enforced by the hardware specific
     /// implementations of [`EsbPayloadLength::set_payload_length()`](fn@crate::radio::prelude::EsbPayloadLength::set_payload_length).
@@ -452,7 +452,7 @@ impl EsbConfig {
 
     // Close a RX pipe from receiving data.
     //
-    // This is only useful if pipe 1 should be closed instead of open (after [`EsbConfig::default()`]).
+    // This is only useful if pipe 1 should be closed instead of open (after [`RadioConfig::default()`]).
     pub fn close_rx_pipe(self, pipe: u8) -> Self {
         let mut pipes = self.pipes;
         pipes.close_rx_pipe(pipe);
@@ -462,12 +462,12 @@ impl EsbConfig {
     /// Is a specified RX pipe open (`true`) or closed (`false`)?
     ///
     /// The value returned here is controlled by
-    /// [`EsbConfig::with_rx_address()`] (to open a pipe) and [`EsbConfig::close_rx_pipe()`].
+    /// [`RadioConfig::with_rx_address()`] (to open a pipe) and [`RadioConfig::close_rx_pipe()`].
     pub fn is_rx_pipe_enabled(&self, pipe: u8) -> bool {
         self.pipes.rx_pipes_enabled & (1u8 << pipe.min(8)) > 0
     }
 
-    /// Get the address for a specified `pipe` set by [`EsbConfig::with_rx_address()`]
+    /// Get the address for a specified `pipe` set by [`RadioConfig::with_rx_address()`]
     pub fn rx_address(&self, pipe: u8, address: &mut [u8]) {
         self.pipes.get_rx_address(pipe, address);
     }
@@ -478,14 +478,14 @@ impl EsbConfig {
     /// For pipes 2 - 5, the 4 LSBytes are used from address set to pipe 1 with the
     /// MSByte from the given `address`.
     ///
-    /// See also [`EsbConfig::with_tx_address()`].
+    /// See also [`RadioConfig::with_tx_address()`].
     pub fn with_rx_address(self, pipe: u8, address: &[u8]) -> Self {
         let mut pipes = self.pipes;
         pipes.set_rx_address(pipe, address);
         Self { pipes, ..self }
     }
 
-    /// Get the address set by [`EsbConfig::with_tx_address()`]
+    /// Get the address set by [`RadioConfig::with_tx_address()`]
     pub fn tx_address(&self, address: &mut [u8]) {
         let len = address.len().min(5);
         address[..len].copy_from_slice(&self.pipes.tx_address[..len]);
@@ -503,12 +503,12 @@ impl EsbConfig {
 
 #[cfg(test)]
 mod test {
-    use super::EsbConfig;
+    use super::RadioConfig;
     use crate::{CrcLength, DataRate, PaLevel};
 
     #[test]
     fn crc_length() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         for len in [CrcLength::Disabled, CrcLength::Bit16, CrcLength::Bit8] {
             config = config.with_crc_length(len);
             assert_eq!(len, config.crc_length());
@@ -517,7 +517,7 @@ mod test {
 
     #[test]
     fn config_irq_flags() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         assert!(config.rx_dr());
         assert!(config.tx_ds());
         assert!(config.tx_df());
@@ -529,7 +529,7 @@ mod test {
 
     #[test]
     fn address_length() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         for len in 0..10 {
             config = config.with_address_length(len);
             assert_eq!(config.address_length(), len.clamp(2, 5));
@@ -538,7 +538,7 @@ mod test {
 
     #[test]
     fn pa_level() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         for level in [PaLevel::Max, PaLevel::High, PaLevel::Low, PaLevel::Min] {
             config = config.with_pa_level(level);
             assert_eq!(config.pa_level(), level);
@@ -550,7 +550,7 @@ mod test {
 
     #[test]
     fn data_rate() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         for rate in [DataRate::Kbps250, DataRate::Mbps1, DataRate::Mbps2] {
             config = config.with_data_rate(rate);
             assert_eq!(config.data_rate(), rate);
@@ -559,7 +559,7 @@ mod test {
 
     #[test]
     fn feature_register() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         assert_eq!(config.auto_ack(), 0x3F);
         assert!(!config.ack_payloads());
         assert!(!config.dynamic_payloads());
@@ -588,18 +588,18 @@ mod test {
 
     #[test]
     fn payload_length() {
-        let config = EsbConfig::default().with_payload_length(255);
+        let config = RadioConfig::default().with_payload_length(255);
         assert_eq!(config.payload_length(), 255);
     }
 
     #[test]
     fn channel() {
-        let config = EsbConfig::default().with_channel(255);
+        let config = RadioConfig::default().with_channel(255);
         assert_eq!(config.channel(), 125);
     }
     #[test]
     fn auto_retries() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         assert_eq!(config.auto_retry_count(), 15);
         assert_eq!(config.auto_retry_delay(), 5);
         config = config.with_auto_retries(20, 3);
@@ -609,7 +609,7 @@ mod test {
 
     #[test]
     fn pipe_addresses() {
-        let mut config = EsbConfig::default();
+        let mut config = RadioConfig::default();
         let mut address = [0xB0; 5];
         config = config.with_tx_address(&address);
         let mut result = [0; 3];

--- a/crates/rf24-rs/src/radio/mod.rs
+++ b/crates/rf24-rs/src/radio/mod.rs
@@ -5,4 +5,4 @@ mod rf24;
 pub use rf24::{Nrf24Error, RF24};
 
 mod config;
-pub use config::EsbConfig;
+pub use config::RadioConfig;

--- a/crates/rf24-rs/src/radio/prelude.rs
+++ b/crates/rf24-rs/src/radio/prelude.rs
@@ -10,7 +10,7 @@
 
 use crate::types::{CrcLength, DataRate, FifoState, PaLevel, StatusFlags};
 
-use super::EsbConfig;
+use super::RadioConfig;
 
 /// A trait to represent manipulation of data pipes
 /// for an ESB capable transceiver.
@@ -449,7 +449,7 @@ pub trait EsbInit {
 
     /// Initialize the radio's hardware.
     ///
-    /// This is similar to [`EsbInit::with_config()`] (with [`EsbConfig::default()`]),
+    /// This is similar to [`EsbInit::with_config()`] (with [`RadioConfig::default()`]),
     /// but this function also
     ///
     /// - waits 5 milliseconds for radio to finish powering up
@@ -463,10 +463,10 @@ pub trait EsbInit {
 
     /// Reconfigure the radio using the given `config` object.
     ///
-    /// See [`EsbConfig`] for more detail.
+    /// See [`RadioConfig`] for more detail.
     /// This function is a convenience where calling multiple configuration functions may
     /// be cumbersome.
-    fn with_config(&mut self, config: &EsbConfig) -> Result<(), Self::ConfigErrorType>;
+    fn with_config(&mut self, config: &RadioConfig) -> Result<(), Self::ConfigErrorType>;
 }
 
 /// A trait to represent manipulation of an ESB capable transceiver.

--- a/crates/rf24-rs/src/radio/rf24/init.rs
+++ b/crates/rf24-rs/src/radio/rf24/init.rs
@@ -2,7 +2,7 @@ use super::{data_rate::set_tx_delay, registers, Feature, Nrf24Error, RF24};
 use crate::{
     radio::{
         prelude::{EsbChannel, EsbFifo, EsbInit, EsbPayloadLength, EsbPipe, EsbPower, EsbStatus},
-        EsbConfig,
+        RadioConfig,
     },
     StatusFlags,
 };
@@ -46,10 +46,10 @@ where
             // MCU may have reset without triggering a power-on-reset in radio.
             self.toggle_features()?;
         }
-        self.with_config(&EsbConfig::default())
+        self.with_config(&RadioConfig::default())
     }
 
-    fn with_config(&mut self, config: &EsbConfig) -> Result<(), Self::ConfigErrorType> {
+    fn with_config(&mut self, config: &RadioConfig) -> Result<(), Self::ConfigErrorType> {
         self.clear_status_flags(StatusFlags::new())?;
         self.power_down()?;
 

--- a/examples/rust/src/bin/quick_config.rs
+++ b/examples/rust/src/bin/quick_config.rs
@@ -10,7 +10,7 @@
 use anyhow::Result;
 
 use rf24::{
-    radio::{prelude::*, EsbConfig, RF24},
+    radio::{prelude::*, RadioConfig, RF24},
     CrcLength,
 };
 use rf24_rs_examples::debug_err;
@@ -54,12 +54,12 @@ impl App {
     /// Configure the radio for 2 different scenarios and
     /// print the configuration details for each.
     pub fn run(&mut self) -> Result<()> {
-        let normal_context = EsbConfig::default()
+        let normal_context = RadioConfig::default()
             .with_rx_address(1, b"1Node")
             .with_tx_address(b"2Node");
 
         let ble_addr = [0x71, 0x91, 0x7d, 0x6b];
-        let ble_context = EsbConfig::default()
+        let ble_context = RadioConfig::default()
             .with_channel(2) // BLE specs hop/rotate amongst channels 2, 26, and 80
             .with_crc_length(CrcLength::Disabled)
             .with_auto_ack(0)


### PR DESCRIPTION
Bindings are unaffected, but rust source suffers a breaking change.

This is meant to unify the API used in bindings and rust.