### PR TITLE
refactor: improve `rf24-rs` tests

### DIFF
--- a/crates/rf24-rs/src/radio/rf24/bit_fields.rs
+++ b/crates/rf24-rs/src/radio/rf24/bit_fields.rs
@@ -30,7 +30,7 @@ pub(crate) struct Config {
 }
 
 impl Config {
-    const CRC_MASK: u8 = 0b1100;
+    pub(crate) const CRC_MASK: u8 = 0b1100;
 
     pub const fn crc_length(&self) -> CrcLength {
         CrcLength::from_bits(self.into_bits() & Self::CRC_MASK)

--- a/crates/rf24-rs/src/radio/rf24/channel.rs
+++ b/crates/rf24-rs/src/radio/rf24/channel.rs
@@ -28,34 +28,23 @@ where
 #[cfg(test)]
 mod test {
     extern crate std;
-    use crate::radio::prelude::EsbChannel;
-    use crate::spi_test_expects;
-
-    use super::{registers, RF24};
-    use embedded_hal_mock::eh1::delay::NoopDelay;
-    use embedded_hal_mock::eh1::digital::Mock as PinMock;
-    use embedded_hal_mock::eh1::spi::{Mock as SpiMock, Transaction as SpiTransaction};
+    use super::{registers, EsbChannel};
+    use crate::{spi_test_expects, test::mk_radio};
+    use embedded_hal_mock::eh1::spi::Transaction as SpiTransaction;
     use std::vec;
 
     // set_channel() is already tested in RF24::init() and RF24::start_carrier_wave()
 
     #[test]
     pub fn get_channel() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // get the RF_CH register value
             (vec![registers::RF_CH, 0u8], vec![0xEu8, 76u8]),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         assert_eq!(radio.get_channel().unwrap(), 76u8);
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/crc_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/crc_length.rs
@@ -14,7 +14,7 @@ where
 
     fn get_crc_length(&mut self) -> Result<CrcLength, Self::CrcLengthErrorType> {
         self.spi_read(1, registers::CONFIG)?;
-        if self._buf[1] & 12 == 4 {
+        if self._buf[1] & Config::CRC_MASK == 4 {
             return Err(Nrf24Error::BinaryCorruption);
         }
         self._config_reg = Config::from_bits(self._buf[1]);
@@ -33,25 +33,13 @@ where
 #[cfg(test)]
 mod test {
     extern crate std;
-    use crate::radio::prelude::EsbCrcLength;
-    use crate::radio::rf24::commands;
-    use crate::{spi_test_expects, CrcLength};
-
-    use super::{registers, RF24};
-    use embedded_hal_mock::eh1::delay::NoopDelay;
-    use embedded_hal_mock::eh1::digital::Mock as PinMock;
-    use embedded_hal_mock::eh1::spi::{Mock as SpiMock, Transaction as SpiTransaction};
+    use super::{registers, EsbCrcLength};
+    use crate::{radio::rf24::commands, spi_test_expects, test::mk_radio, CrcLength};
+    use embedded_hal_mock::eh1::spi::Transaction as SpiTransaction;
     use std::vec;
 
     #[test]
     pub fn get_crc_length() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // get the CONFIG register value for each possible result
             (vec![registers::CONFIG, 0u8], vec![0xEu8, 0u8]),
@@ -59,8 +47,8 @@ mod test {
             (vec![registers::CONFIG, 0x8u8], vec![0xEu8, 0xCu8]),
             (vec![registers::CONFIG, 0xCu8], vec![0xEu8, 4u8]),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         assert_eq!(radio.get_crc_length(), Ok(CrcLength::Disabled));
         assert_eq!(radio.get_crc_length(), Ok(CrcLength::Bit8));
         assert_eq!(radio.get_crc_length(), Ok(CrcLength::Bit16));
@@ -68,19 +56,12 @@ mod test {
             radio.get_crc_length(),
             Err(crate::radio::Nrf24Error::BinaryCorruption)
         );
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 
     #[test]
     pub fn set_crc_length() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // set the CONFIG register value for each possible enumeration of CrcLength
             (vec![registers::CONFIG, 0u8], vec![0xEu8, 4u8]),
@@ -99,12 +80,12 @@ mod test {
                 vec![0xEu8, 0u8],
             ),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         radio.set_crc_length(CrcLength::Disabled).unwrap();
         radio.set_crc_length(CrcLength::Bit8).unwrap();
         radio.set_crc_length(CrcLength::Bit16).unwrap();
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/details.rs
+++ b/crates/rf24-rs/src/radio/rf24/details.rs
@@ -277,27 +277,15 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::radio::prelude::EsbDetails;
-    use crate::radio::RF24;
-    use embedded_hal_mock::eh1::delay::NoopDelay;
-    use embedded_hal_mock::eh1::digital::Mock as PinMock;
-    use embedded_hal_mock::eh1::spi::Mock as SpiMock;
+    use super::EsbDetails;
+    use crate::test::mk_radio;
 
     #[test]
     fn print_nothing() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
-        // create spi device
-        let spi_expectations = [];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &[]);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         assert!(radio.print_details().is_ok());
-        pin_mock.done();
-        spi_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/power.rs
+++ b/crates/rf24-rs/src/radio/rf24/power.rs
@@ -61,25 +61,13 @@ where
 #[cfg(test)]
 mod test {
     extern crate std;
-    use crate::radio::prelude::EsbPower;
-    use crate::radio::rf24::commands;
-    use crate::spi_test_expects;
-
-    use super::{registers, RF24};
-    use embedded_hal_mock::eh1::delay::NoopDelay;
-    use embedded_hal_mock::eh1::digital::Mock as PinMock;
-    use embedded_hal_mock::eh1::spi::{Mock as SpiMock, Transaction as SpiTransaction};
+    use super::{registers, EsbPower};
+    use crate::{radio::rf24::commands, spi_test_expects, test::mk_radio};
+    use embedded_hal_mock::eh1::spi::Transaction as SpiTransaction;
     use std::vec;
 
     #[test]
     pub fn power_up() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // get the RF_SETUP register value for each possible result
             (
@@ -87,23 +75,16 @@ mod test {
                 vec![0xEu8, 0u8],
             ),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         radio.power_up(None).unwrap();
         radio.power_up(None).unwrap();
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 
     #[test]
     pub fn power_up_no_blocking() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // get the RF_SETUP register value for each possible result
             (
@@ -111,23 +92,16 @@ mod test {
                 vec![0xEu8, 0u8],
             ),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         radio.power_up(Some(0)).unwrap();
         assert!(radio.is_powered());
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 
     #[test]
     pub fn power_up_custom_delay() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // get the RF_SETUP register value for each possible result
             (
@@ -135,28 +109,20 @@ mod test {
                 vec![0xEu8, 0u8],
             ),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         radio.power_up(Some(5000)).unwrap();
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 
     #[test]
     pub fn power_getter() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
-        let spi_expectations = vec![];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &[]);
+        let (radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         // without calling `RF24::init()`, the lib _assumes_ the radio is powered down.
         assert!(!radio.is_powered());
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/status.rs
+++ b/crates/rf24-rs/src/radio/rf24/status.rs
@@ -17,8 +17,9 @@ where
 
     fn set_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::StatusErrorType> {
         self.spi_read(1, registers::CONFIG)?;
-        self._config_reg =
-            Config::from_bits(self._buf[1] & 0x0F | (!flags.into_bits() & StatusFlags::IRQ_MASK));
+        self._config_reg = Config::from_bits(
+            self._buf[1] & !StatusFlags::IRQ_MASK | (!flags.into_bits() & StatusFlags::IRQ_MASK),
+        );
         self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())
     }
 
@@ -40,51 +41,31 @@ where
 #[cfg(test)]
 mod test {
     extern crate std;
-    use crate::radio::prelude::EsbStatus;
-    use crate::radio::rf24::commands;
-    use crate::spi_test_expects;
-    use crate::types::StatusFlags;
-
-    use super::{registers, RF24};
-    use embedded_hal_mock::eh1::delay::NoopDelay;
-    use embedded_hal_mock::eh1::digital::Mock as PinMock;
-    use embedded_hal_mock::eh1::spi::{Mock as SpiMock, Transaction as SpiTransaction};
+    use super::{commands, registers, EsbStatus, StatusFlags};
+    use crate::{spi_test_expects, test::mk_radio};
+    use embedded_hal_mock::eh1::spi::Transaction as SpiTransaction;
     use std::vec;
 
     #[test]
     pub fn what_happened() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // get the RF_SETUP register value for each possible result
             (vec![commands::NOP], vec![0x70u8]),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         radio.update().unwrap();
         let mut flags = StatusFlags::default();
         radio.get_status_flags(&mut flags);
         assert!(flags.rx_dr());
         assert!(flags.tx_ds());
         assert!(flags.tx_df());
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 
     #[test]
     pub fn set_status_flags() {
-        // Create pin
-        let pin_expectations = [];
-        let mut pin_mock = PinMock::new(&pin_expectations);
-
-        // create delay fn
-        let delay_mock = NoopDelay::new();
-
         let spi_expectations = spi_test_expects![
             // read the CONFIG register value
             (vec![registers::CONFIG, 0u8], vec![0xEu8, 0xFu8]),
@@ -94,10 +75,10 @@ mod test {
                 vec![0xEu8, 0u8],
             ),
         ];
-        let mut spi_mock = SpiMock::new(&spi_expectations);
-        let mut radio = RF24::new(pin_mock.clone(), spi_mock.clone(), delay_mock);
+        let mocks = mk_radio(&[], &spi_expectations);
+        let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
         radio.set_status_flags(StatusFlags::default()).unwrap();
-        spi_mock.done();
-        pin_mock.done();
+        spi.done();
+        ce_pin.done();
     }
 }

--- a/crates/rf24-rs/src/types.rs
+++ b/crates/rf24-rs/src/types.rs
@@ -44,6 +44,8 @@ impl defmt::Format for PaLevel {
 }
 
 impl PaLevel {
+    pub(crate) const MASK: u8 = 6;
+
     pub(crate) const fn into_bits(self) -> u8 {
         match self {
             PaLevel::Min => 0,
@@ -85,6 +87,8 @@ pub enum DataRate {
 }
 
 impl DataRate {
+    pub(crate) const MASK: u8 = 0x28;
+
     pub(crate) const fn into_bits(self) -> u8 {
         match self {
             DataRate::Mbps1 => 0,


### PR DESCRIPTION
also adds some constants for bitwise masks to replace magic numbers