### PR TITLE
chore: update dependabot npm config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,7 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: npm
-    directories: ['**/package.json']
+    directory: /
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
fixes config telling dependabot where the package.json manifest for npm/yarn-related updates.