### PR TITLE
fix: use const for max BLE payload size

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           target: ${{ matrix.platform.target }}
           args: --release --out dist --find-interpreter
-          sccache: 'true'
+          # sccache: 'true'
           manylinux: auto
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/crates/rf24ble-rs/src/radio.rs
+++ b/crates/rf24ble-rs/src/radio.rs
@@ -242,7 +242,7 @@ impl FakeBle {
             offset += len;
         }
 
-        if payload_length > 28 {
+        if payload_length > BlePayload::MAX_BLE_PAYLOAD_SIZE as usize {
             return None;
         }
 

--- a/crates/rf24ble-rs/src/services.rs
+++ b/crates/rf24ble-rs/src/services.rs
@@ -289,6 +289,8 @@ pub struct BlePayload {
 }
 
 impl BlePayload {
+    pub(crate) const MAX_BLE_PAYLOAD_SIZE: u8 = 27;
+
     pub fn from_bytes(buf: &mut [u8], channel: u8) -> Option<Self> {
         use prelude::FromBuffer;
 
@@ -296,11 +298,11 @@ impl BlePayload {
         let coefficient = (BleChannels::index_of(channel).unwrap_or_default() as u8 + 37) | 0x40;
         whiten(buf, coefficient);
 
-        let len = buf[1] as usize;
-        if len > 27 {
+        let len = buf[1];
+        if len > Self::MAX_BLE_PAYLOAD_SIZE {
             return None;
         }
-        let len = len + 2;
+        let len = len as usize + 2;
 
         let mut crc = [0u8; 3];
         crc.copy_from_slice(&buf[len..len + 3]);


### PR DESCRIPTION
This replaces the magic number which was inconsistent between RX and TX BLE operations.

This also avoids possible malformed outgoing payloads because 28 was previously used where 27 is the correct maximum.