### PR TITLE
refactor: concrete error type and cached TX address

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,7 +15,7 @@ slow-timeout = "10s"
 # This is all tests in tests/ folder + unit test for --extra-args.
 default-filter = "all()"
 
-# show wich tests were skipped
+# show which tests were skipped
 status-level = "skip"
 
 # show log output from each test

--- a/bindings/node/src/radio/config.rs
+++ b/bindings/node/src/radio/config.rs
@@ -8,7 +8,7 @@ use napi::{bindgen_prelude::Buffer, JsNumber, Result};
 #[derive(Debug, Clone, Copy)]
 pub struct RadioConfig {
     inner: rf24::radio::RadioConfig,
-    _addr_buf: [u8; 5],
+    addr_buf: [u8; 5],
 }
 
 #[napi]
@@ -53,7 +53,7 @@ impl RadioConfig {
     pub fn new() -> Self {
         Self {
             inner: rf24::radio::RadioConfig::default(),
-            _addr_buf: [0u8; 5],
+            addr_buf: [0u8; 5],
         }
     }
 
@@ -344,8 +344,8 @@ impl RadioConfig {
     /// Get the address for a specified `pipe` set by {@link RadioConfig.setRxAddress}.
     #[napi]
     pub fn get_rx_address(&mut self, pipe: u8) -> Buffer {
-        self.inner.rx_address(pipe, &mut self._addr_buf);
-        Buffer::from(self._addr_buf.to_vec())
+        self.inner.rx_address(pipe, &mut self.addr_buf);
+        Buffer::from(self.addr_buf.to_vec())
     }
 
     /// Set the TX address.
@@ -359,8 +359,8 @@ impl RadioConfig {
 
     #[napi(getter, js_name = "txAddress")]
     pub fn get_tx_address(&mut self) -> Buffer {
-        self.inner.tx_address(&mut self._addr_buf);
-        Buffer::from(self._addr_buf.to_vec())
+        self.inner.tx_address(&mut self.addr_buf);
+        Buffer::from(self.addr_buf.to_vec())
     }
 
     /// Close a RX pipe from receiving data.
@@ -381,7 +381,7 @@ impl RadioConfig {
     pub fn from_inner(config: rf24::radio::RadioConfig) -> Self {
         Self {
             inner: config,
-            _addr_buf: [0u8; 5],
+            addr_buf: [0u8; 5],
         }
     }
 }

--- a/bindings/node/src/radio/interface.rs
+++ b/bindings/node/src/radio/interface.rs
@@ -196,6 +196,10 @@ impl RF24 {
 
     /// Put the radio into active RX mode.
     ///
+    /// This function will restore the cached RX address set to pipe 0.
+    /// This is done because the {@link RF24.asTx} will
+    /// appropriate the RX address on pipe 0 for auto-ack purposes.
+    ///
     /// @group Basic
     #[napi]
     pub fn as_rx(&mut self) -> Result<()> {
@@ -211,6 +215,15 @@ impl RF24 {
     /// > [!NOTE]
     /// > This function will also flush the TX FIFO when ACK payloads are enabled
     /// > (via {@link RF24.ackPayloads}).
+    ///
+    /// This must be called at least once before calling
+    /// {@link RF24.send) or {@link RF24.write).
+    /// Conventionally, this should be called before setting the TX address via
+    /// {@link RF24.openTxPipe).
+    ///
+    /// For auto-ack purposes, this function will also restore the cached
+    /// TX address (passed to {@link RF24.openTxPipe))
+    /// to the RX pipe 0.
     ///
     /// @group Basic
     #[napi]

--- a/bindings/node/src/radio/interface.rs
+++ b/bindings/node/src/radio/interface.rs
@@ -217,12 +217,12 @@ impl RF24 {
     /// > (via {@link RF24.ackPayloads}).
     ///
     /// This must be called at least once before calling
-    /// {@link RF24.send) or {@link RF24.write).
+    /// {@link RF24.send} or {@link RF24.write}.
     /// Conventionally, this should be called before setting the TX address via
-    /// {@link RF24.openTxPipe).
+    /// {@link RF24.openTxPipe}.
     ///
     /// For auto-ack purposes, this function will also restore the cached
-    /// TX address (passed to {@link RF24.openTxPipe))
+    /// TX address (passed to {@link RF24.openTxPipe})
     /// to the RX pipe 0.
     ///
     /// @group Basic
@@ -779,7 +779,7 @@ impl RF24 {
     /// Only pipe 0 can be used for transmitting. It is highly recommended to
     /// avoid using pipe 0 to receive because of this.
     ///
-    /// @param address - The address to receive data from.
+    /// @param address - The address to transmit data to.
     ///
     /// @group Basic
     #[napi]

--- a/bindings/python/src/radio/config.rs
+++ b/bindings/python/src/radio/config.rs
@@ -44,7 +44,7 @@ use std::borrow::Cow;
 #[derive(Debug, Clone, Copy)]
 pub struct RadioConfig {
     inner: rf24::radio::RadioConfig,
-    _addr_buf: [u8; 5],
+    addr_buf: [u8; 5],
 }
 
 #[pymethods]
@@ -53,7 +53,7 @@ impl RadioConfig {
     pub fn new() -> Self {
         Self {
             inner: rf24::radio::RadioConfig::default(),
-            _addr_buf: [0u8; 5],
+            addr_buf: [0u8; 5],
         }
     }
 
@@ -305,8 +305,8 @@ impl RadioConfig {
 
     /// Get the address for a specified `pipe` set by [`RadioConfig.set_rx_address()`][rf24_py.RadioConfig.set_rx_address].
     pub fn get_rx_address(&mut self, pipe: u8) -> Cow<[u8]> {
-        self.inner.rx_address(pipe, &mut self._addr_buf);
-        Cow::from(&self._addr_buf)
+        self.inner.rx_address(pipe, &mut self.addr_buf);
+        Cow::from(&self.addr_buf)
     }
 
     /// Set the TX address.
@@ -314,8 +314,8 @@ impl RadioConfig {
     /// Only pipe 0 can be used for TX operations (including auto-ACK packets during RX operations).
     #[getter]
     pub fn get_tx_address(&mut self) -> Cow<[u8]> {
-        self.inner.tx_address(&mut self._addr_buf);
-        Cow::from(&self._addr_buf)
+        self.inner.tx_address(&mut self.addr_buf);
+        Cow::from(&self.addr_buf)
     }
 
     #[setter]
@@ -339,7 +339,7 @@ impl RadioConfig {
     pub fn from_inner(config: rf24::radio::RadioConfig) -> Self {
         Self {
             inner: config,
-            _addr_buf: [0u8; 5],
+            addr_buf: [0u8; 5],
         }
     }
 }

--- a/bindings/python/src/radio/interface.rs
+++ b/bindings/python/src/radio/interface.rs
@@ -668,7 +668,7 @@ impl RF24 {
     /// avoid using pipe 0 to receive because of this.
     ///
     /// Parameters:
-    ///     address: The address to receive data from.
+    ///     address: The address to transmit data to.
     pub fn open_tx_pipe(&mut self, address: &[u8]) -> PyResult<()> {
         self.inner
             .open_tx_pipe(address)

--- a/bindings/python/src/radio/interface.rs
+++ b/bindings/python/src/radio/interface.rs
@@ -173,6 +173,10 @@ impl RF24 {
     }
 
     /// Put the radio into active RX mode.
+    ///
+    /// This function will restore the cached RX address set to pipe 0.
+    /// This is done because the [`RF24.as_tx()`][rf24_py.RF24.as_tx] will
+    /// appropriate the RX address on pipe 0 for auto-ack purposes.
     pub fn as_rx(&mut self) -> PyResult<()> {
         self.inner
             .as_rx()
@@ -186,6 +190,16 @@ impl RF24 {
     /// Note:
     ///     This function will also flush the TX FIFO when ACK payloads are enabled
     ///     (via [`RF24.ack_payloads`][rf24_py.RF24.ack_payloads]).
+    ///
+    /// This must be called at least once before calling
+    /// [`RF24.send()`][rf24_py.RF24.send] or
+    /// [`RF24.write()`][rf24_py.RF24.write].
+    /// Conventionally, this should be called before setting the TX address via
+    /// [`RF24.open_tx_pipe()`][rf24_py.RF24.open_tx_pipe].
+    ///
+    /// For auto-ack purposes, this function will also restore the cached
+    /// TX address (passed to [`RF24.open_tx_pipe()`][rf24_py.RF24.open_tx_pipe])
+    /// to the RX pipe 0.
     pub fn as_tx(&mut self) -> PyResult<()> {
         self.inner
             .as_tx()

--- a/crates/rf24-rs/src/radio/prelude.rs
+++ b/crates/rf24-rs/src/radio/prelude.rs
@@ -459,14 +459,21 @@ pub trait EsbRadio: RadioErrorType {
     ///
     /// Conventionally, this should be called after setting the RX addresses via
     /// [`EsbPipe::open_rx_pipe()`]
+    ///
+    /// This function will restore the cached RX address set to pipe 0.
+    /// This is done because the [`EsbRadio::as_tx()`] will appropriate the
+    /// RX address on pipe 0 for auto-ack purposes.
     fn as_rx(&mut self) -> Result<(), Self::Error>;
 
     /// Put the radio into inactive TX mode.
     ///
     /// This must be called at least once before calling [`EsbRadio::send()`] or
     /// [`EsbRadio::write()`].
-    /// Conventionally, this should be called after setting the TX address via
+    /// Conventionally, this should be called before setting the TX address via
     /// [`EsbPipe::open_tx_pipe()`].
+    ///
+    /// For auto-ack purposes, this function will also restore the cached
+    /// TX address (passed to [`EsbPipe::open_tx_pipe()`]) to the RX pipe 0.
     fn as_tx(&mut self) -> Result<(), Self::Error>;
 
     /// Is the radio in RX mode?

--- a/crates/rf24-rs/src/radio/prelude.rs
+++ b/crates/rf24-rs/src/radio/prelude.rs
@@ -24,7 +24,7 @@ pub trait EsbPipe: RadioErrorType {
     ///
     /// If the specified `pipe` is not in range [0, 5], then this function does nothing.
     ///
-    /// Up to 6 pipes can be open for reading at once.  Open all the required
+    /// Up to 6 pipes can be open for reading at once. Open all the required
     /// reading pipes, and then call [`EsbRadio::as_rx()`].
     ///
     /// ### About pipe addresses
@@ -61,6 +61,8 @@ pub trait EsbPipe: RadioErrorType {
 
     /// Set an address to pipe 0 for transmitting when radio is in TX mode.
     ///
+    /// Only pipe 0 can be used for transmitting. It is highly recommended to
+    /// avoid using pipe 0 to receive because of this.
     fn open_tx_pipe(&mut self, address: &[u8]) -> Result<(), Self::Error>;
 
     /// Close a specified pipe from receiving data when radio is in RX mode.

--- a/crates/rf24-rs/src/radio/rf24/auto_ack.rs
+++ b/crates/rf24-rs/src/radio/rf24/auto_ack.rs
@@ -11,14 +11,14 @@ where
     DELAY: DelayNs,
 {
     fn set_ack_payloads(&mut self, enable: bool) -> Result<(), Self::Error> {
-        if self._feature.ack_payloads() != enable {
+        if self.feature.ack_payloads() != enable {
             self.spi_read(1, registers::FEATURE)?;
-            self._feature =
-                Feature::from_bits(self._feature.into_bits() & !Feature::REG_MASK | self._buf[1])
+            self.feature =
+                Feature::from_bits(self.feature.into_bits() & !Feature::REG_MASK | self.buf[1])
                     .with_ack_payloads(enable);
             self.spi_write_byte(
                 registers::FEATURE,
-                self._feature.into_bits() & Feature::REG_MASK,
+                self.feature.into_bits() & Feature::REG_MASK,
             )?;
 
             if enable {
@@ -31,13 +31,13 @@ where
     }
 
     fn get_ack_payloads(&self) -> bool {
-        self._feature.ack_payloads()
+        self.feature.ack_payloads()
     }
 
     fn set_auto_ack(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::EN_AA, 0x3F * enable as u8)?;
         // accommodate ACK payloads feature
-        if !enable && self._feature.ack_payloads() {
+        if !enable && self.feature.ack_payloads() {
             self.set_ack_payloads(false)?;
         }
         Ok(())
@@ -49,8 +49,8 @@ where
         }
         self.spi_read(1, registers::EN_AA)?;
         let mask = 1 << pipe;
-        let reg_val = self._buf[1];
-        if !enable && self._feature.ack_payloads() && pipe == 0 {
+        let reg_val = self.buf[1];
+        if !enable && self.feature.ack_payloads() && pipe == 0 {
             self.set_ack_payloads(enable)?;
         }
         self.spi_write_byte(registers::EN_AA, reg_val & !mask | (mask * enable as u8))
@@ -58,14 +58,14 @@ where
 
     fn allow_ask_no_ack(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_read(1, registers::FEATURE)?;
-        self.spi_write_byte(registers::FEATURE, self._buf[1] & !1 | enable as u8)
+        self.spi_write_byte(registers::FEATURE, self.buf[1] & !1 | enable as u8)
     }
 
     fn write_ack_payload(&mut self, pipe: u8, buf: &[u8]) -> Result<bool, Self::Error> {
-        if self._feature.ack_payloads() && pipe <= 5 {
+        if self.feature.ack_payloads() && pipe <= 5 {
             let len = buf.len().min(32);
             self.spi_write_buf(commands::W_ACK_PAYLOAD | pipe, &buf[..len])?;
-            return Ok(!self._status.tx_full());
+            return Ok(!self.status.tx_full());
         }
         Ok(false)
     }

--- a/crates/rf24-rs/src/radio/rf24/channel.rs
+++ b/crates/rf24-rs/src/radio/rf24/channel.rs
@@ -17,7 +17,7 @@ where
     /// See also [`RF24::set_channel()`].
     fn get_channel(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::RF_CH)?;
-        Ok(self._buf[1])
+        Ok(self.buf[1])
     }
 }
 

--- a/crates/rf24-rs/src/radio/rf24/channel.rs
+++ b/crates/rf24-rs/src/radio/rf24/channel.rs
@@ -1,5 +1,5 @@
 use super::registers;
-use crate::radio::{prelude::EsbChannel, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbChannel, RF24};
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
 impl<SPI, DO, DELAY> EsbChannel for RF24<SPI, DO, DELAY>
@@ -8,16 +8,14 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type ChannelErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     /// The nRF24L01 support 126 channels. The specified `channel` is
     /// clamped to the range [0, 125].
-    fn set_channel(&mut self, channel: u8) -> Result<(), Self::ChannelErrorType> {
+    fn set_channel(&mut self, channel: u8) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::RF_CH, channel.min(125))
     }
 
     /// See also [`RF24::set_channel()`].
-    fn get_channel(&mut self) -> Result<u8, Self::ChannelErrorType> {
+    fn get_channel(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::RF_CH)?;
         Ok(self._buf[1])
     }

--- a/crates/rf24-rs/src/radio/rf24/crc_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/crc_length.rs
@@ -12,17 +12,17 @@ where
 {
     fn get_crc_length(&mut self) -> Result<CrcLength, Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
-        if self._buf[1] & Config::CRC_MASK == 4 {
+        if self.buf[1] & Config::CRC_MASK == 4 {
             return Err(Nrf24Error::BinaryCorruption);
         }
-        self._config_reg = Config::from_bits(self._buf[1]);
-        Ok(self._config_reg.crc_length())
+        self.config_reg = Config::from_bits(self.buf[1]);
+        Ok(self.config_reg.crc_length())
     }
 
     fn set_crc_length(&mut self, crc_length: CrcLength) -> Result<(), Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
-        self._config_reg = self._config_reg.with_crc_length(crc_length);
-        self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())
+        self.config_reg = self.config_reg.with_crc_length(crc_length);
+        self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())
     }
 }
 

--- a/crates/rf24-rs/src/radio/rf24/crc_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/crc_length.rs
@@ -10,9 +10,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type CrcLengthErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn get_crc_length(&mut self) -> Result<CrcLength, Self::CrcLengthErrorType> {
+    fn get_crc_length(&mut self) -> Result<CrcLength, Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
         if self._buf[1] & Config::CRC_MASK == 4 {
             return Err(Nrf24Error::BinaryCorruption);
@@ -21,7 +19,7 @@ where
         Ok(self._config_reg.crc_length())
     }
 
-    fn set_crc_length(&mut self, crc_length: CrcLength) -> Result<(), Self::CrcLengthErrorType> {
+    fn set_crc_length(&mut self, crc_length: CrcLength) -> Result<(), Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
         self._config_reg = self._config_reg.with_crc_length(crc_length);
         self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())

--- a/crates/rf24-rs/src/radio/rf24/data_rate.rs
+++ b/crates/rf24-rs/src/radio/rf24/data_rate.rs
@@ -21,9 +21,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type DataRateErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn get_data_rate(&mut self) -> Result<DataRate, Self::DataRateErrorType> {
+    fn get_data_rate(&mut self) -> Result<DataRate, Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
         let da_bin = self._buf[1] & DataRate::MASK;
         if da_bin == DataRate::MASK {
@@ -32,7 +30,7 @@ where
         Ok(DataRate::from_bits(da_bin))
     }
 
-    fn set_data_rate(&mut self, data_rate: DataRate) -> Result<(), Self::DataRateErrorType> {
+    fn set_data_rate(&mut self, data_rate: DataRate) -> Result<(), Self::Error> {
         self.tx_delay = set_tx_delay(data_rate);
         self.spi_read(1, registers::RF_SETUP)?;
         let da_bin = data_rate.into_bits();

--- a/crates/rf24-rs/src/radio/rf24/data_rate.rs
+++ b/crates/rf24-rs/src/radio/rf24/data_rate.rs
@@ -23,7 +23,7 @@ where
 {
     fn get_data_rate(&mut self) -> Result<DataRate, Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
-        let da_bin = self._buf[1] & DataRate::MASK;
+        let da_bin = self.buf[1] & DataRate::MASK;
         if da_bin == DataRate::MASK {
             return Err(Nrf24Error::BinaryCorruption);
         }
@@ -34,7 +34,7 @@ where
         self.tx_delay = set_tx_delay(data_rate);
         self.spi_read(1, registers::RF_SETUP)?;
         let da_bin = data_rate.into_bits();
-        let out = self._buf[1] & !DataRate::MASK | da_bin;
+        let out = self.buf[1] & !DataRate::MASK | da_bin;
         self.spi_write_byte(registers::RF_SETUP, out)
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/details.rs
+++ b/crates/rf24-rs/src/radio/rf24/details.rs
@@ -1,4 +1,4 @@
-use super::{Nrf24Error, RF24};
+use super::RF24;
 use crate::radio::prelude::EsbDetails;
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
@@ -18,11 +18,9 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type DetailsErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     #[cfg(feature = "defmt")]
     #[cfg(target_os = "none")]
-    fn print_details(&mut self) -> Result<(), Self::DetailsErrorType> {
+    fn print_details(&mut self) -> Result<(), Self::Error> {
         defmt::println!("Is a plus variant_________{=bool}", self.is_plus_variant());
 
         let channel = self.get_channel()?;
@@ -157,13 +155,13 @@ where
     }
 
     #[cfg(not(any(feature = "defmt", feature = "std")))]
-    fn print_details(&mut self) -> Result<(), Self::DetailsErrorType> {
+    fn print_details(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 
     #[cfg(not(target_os = "none"))]
     #[cfg(feature = "std")]
-    fn print_details(&mut self) -> Result<(), Self::DetailsErrorType> {
+    fn print_details(&mut self) -> Result<(), Self::Error> {
         use crate::radio::rf24::Config;
 
         std::println!("Is a plus variant_________{}", self.is_plus_variant());

--- a/crates/rf24-rs/src/radio/rf24/fifo.rs
+++ b/crates/rf24-rs/src/radio/rf24/fifo.rs
@@ -13,7 +13,7 @@ where
 {
     fn available(&mut self) -> Result<bool, Self::Error> {
         self.spi_read(1, registers::FIFO_STATUS)?;
-        Ok(self._buf[1] & 1 == 0)
+        Ok(self.buf[1] & 1 == 0)
     }
 
     fn available_pipe(&mut self, pipe: &mut u8) -> Result<bool, Self::Error> {
@@ -21,7 +21,7 @@ where
             // RX FIFO is not empty
             // get last used pipe
             self.spi_read(0, commands::NOP)?;
-            *pipe = self._status.rx_pipe();
+            *pipe = self.status.rx_pipe();
             return Ok(true);
         }
         Ok(false)
@@ -40,7 +40,7 @@ where
     fn get_fifo_state(&mut self, about_tx: bool) -> Result<FifoState, Self::Error> {
         self.spi_read(1, registers::FIFO_STATUS)?;
         let offset = about_tx as u8 * 4;
-        let status = (self._buf[1] & (3 << offset)) >> offset;
+        let status = (self.buf[1] & (3 << offset)) >> offset;
         match status {
             1 => Ok(FifoState::Empty),
             2 => Ok(FifoState::Full),

--- a/crates/rf24-rs/src/radio/rf24/fifo.rs
+++ b/crates/rf24-rs/src/radio/rf24/fifo.rs
@@ -55,8 +55,8 @@ where
 #[cfg(test)]
 mod test {
     extern crate std;
-    use super::{commands, registers, EsbFifo, FifoState};
-    use crate::{radio::Nrf24Error, spi_test_expects, test::mk_radio};
+    use super::{commands, registers, EsbFifo, FifoState, Nrf24Error};
+    use crate::{spi_test_expects, test::mk_radio};
     use embedded_hal_mock::eh1::spi::Transaction as SpiTransaction;
     use std::vec;
 

--- a/crates/rf24-rs/src/radio/rf24/init.rs
+++ b/crates/rf24-rs/src/radio/rf24/init.rs
@@ -23,21 +23,21 @@ where
         // Enabling 16b CRC is by far the most obvious case if the wrong timing is used - or skipped.
         // Technically we require 4.5ms + 14us as a worst case. We'll just call it 5ms for good measure.
         // WARNING: Delay is based on P-variant whereby non-P *may* require different timing.
-        self._delay_impl.delay_ns(5000000);
+        self.delay_impl.delay_ns(5000000);
 
         self.power_down()?;
         self.spi_read(1, registers::CONFIG)?;
-        if self._buf[1] != self._config_reg.into_bits() {
+        if self.buf[1] != self.config_reg.into_bits() {
             return Err(Nrf24Error::BinaryCorruption);
         }
 
         // detect if is a plus variant & use old toggle features command accordingly
         self.spi_read(1, registers::FEATURE)?;
-        let before_toggle = self._buf[1];
+        let before_toggle = self.buf[1];
         self.toggle_features()?;
         self.spi_read(1, registers::FEATURE)?;
-        let after_toggle = self._buf[1];
-        self._feature
+        let after_toggle = self.buf[1];
+        self.feature
             .set_is_plus_variant(before_toggle == after_toggle);
         if after_toggle < before_toggle {
             // FEATURE register is disabled on non-plus variants until `toggle_features()` is used.
@@ -59,14 +59,14 @@ where
 
         self.spi_write_byte(registers::SETUP_RETR, config.auto_retries.into_bits())?;
         self.spi_write_byte(registers::EN_AA, config.auto_ack())?;
-        self._feature = Feature::from_bits(
-            self._feature.into_bits() & !Feature::REG_MASK
+        self.feature = Feature::from_bits(
+            self.feature.into_bits() & !Feature::REG_MASK
                 | (config.feature.into_bits() & Feature::REG_MASK),
         );
         self.spi_write_byte(registers::DYNPD, 0x3F * (config.dynamic_payloads() as u8))?;
         self.spi_write_byte(
             registers::FEATURE,
-            self._feature.into_bits() & Feature::REG_MASK,
+            self.feature.into_bits() & Feature::REG_MASK,
         )?;
 
         let setup_rf_reg_val = config.setup_rf_aw.into_bits() & 0x27u8;
@@ -97,8 +97,8 @@ where
         //      Enable PTX
         // Do not write CE high so radio will remain in standby-I mode.
         // PTX should use only 22uA of power in standby-I mode.
-        self._config_reg = config.config_reg.with_power(true);
-        self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())
+        self.config_reg = config.config_reg.with_power(true);
+        self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())
     }
 }
 

--- a/crates/rf24-rs/src/radio/rf24/init.rs
+++ b/crates/rf24-rs/src/radio/rf24/init.rs
@@ -14,11 +14,9 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type ConfigErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     /// Initialize the radio's hardware using the [`SpiDevice`] and [`OutputPin`] given
     /// to [`RF24::new()`].
-    fn init(&mut self) -> Result<(), Self::ConfigErrorType> {
+    fn init(&mut self) -> Result<(), Self::Error> {
         // Must allow the radio time to settle else configuration bits will not necessarily stick.
         // This is actually only required following power up but some settling time also appears to
         // be required after resets too. For full coverage, we'll always assume the worst.
@@ -49,7 +47,7 @@ where
         self.with_config(&RadioConfig::default())
     }
 
-    fn with_config(&mut self, config: &RadioConfig) -> Result<(), Self::ConfigErrorType> {
+    fn with_config(&mut self, config: &RadioConfig) -> Result<(), Self::Error> {
         self.clear_status_flags(StatusFlags::new())?;
         self.power_down()?;
 

--- a/crates/rf24-rs/src/radio/rf24/pa_level.rs
+++ b/crates/rf24-rs/src/radio/rf24/pa_level.rs
@@ -1,7 +1,7 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
 use super::registers;
-use crate::radio::{prelude::EsbPaLevel, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbPaLevel, RF24};
 use crate::PaLevel;
 
 impl<SPI, DO, DELAY> EsbPaLevel for RF24<SPI, DO, DELAY>
@@ -10,14 +10,12 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type PaLevelErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn get_pa_level(&mut self) -> Result<PaLevel, Self::PaLevelErrorType> {
+    fn get_pa_level(&mut self) -> Result<PaLevel, Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
         Ok(PaLevel::from_bits(self._buf[1] & PaLevel::MASK))
     }
 
-    fn set_pa_level(&mut self, pa_level: PaLevel) -> Result<(), Self::PaLevelErrorType> {
+    fn set_pa_level(&mut self, pa_level: PaLevel) -> Result<(), Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
         let out = self._buf[1] & !PaLevel::MASK | pa_level.into_bits();
         self.spi_write_byte(registers::RF_SETUP, out)

--- a/crates/rf24-rs/src/radio/rf24/pa_level.rs
+++ b/crates/rf24-rs/src/radio/rf24/pa_level.rs
@@ -12,12 +12,12 @@ where
 {
     fn get_pa_level(&mut self) -> Result<PaLevel, Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
-        Ok(PaLevel::from_bits(self._buf[1] & PaLevel::MASK))
+        Ok(PaLevel::from_bits(self.buf[1] & PaLevel::MASK))
     }
 
     fn set_pa_level(&mut self, pa_level: PaLevel) -> Result<(), Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
-        let out = self._buf[1] & !PaLevel::MASK | pa_level.into_bits();
+        let out = self.buf[1] & !PaLevel::MASK | pa_level.into_bits();
         self.spi_write_byte(registers::RF_SETUP, out)
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/payload_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/payload_length.rs
@@ -14,38 +14,38 @@ where
         for i in 0..6 {
             self.spi_write_byte(registers::RX_PW_P0 + i, len)?;
         }
-        self._payload_length = len;
+        self.payload_length = len;
         Ok(())
     }
 
     fn get_payload_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::RX_PW_P0)?;
-        Ok(self._buf[1])
+        Ok(self.buf[1])
     }
 
     fn set_dynamic_payloads(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_read(1, registers::FEATURE)?;
-        self._feature =
-            Feature::from_bits(self._feature.into_bits() & !Feature::REG_MASK | self._buf[1])
+        self.feature =
+            Feature::from_bits(self.feature.into_bits() & !Feature::REG_MASK | self.buf[1])
                 .with_dynamic_payloads(enable);
         self.spi_write_byte(
             registers::FEATURE,
-            self._feature.into_bits() & Feature::REG_MASK,
+            self.feature.into_bits() & Feature::REG_MASK,
         )?;
         self.spi_write_byte(registers::DYNPD, 0x3F * enable as u8)?;
         Ok(())
     }
 
     fn get_dynamic_payloads(&self) -> bool {
-        self._feature.dynamic_payloads()
+        self.feature.dynamic_payloads()
     }
 
     fn get_dynamic_payload_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, commands::R_RX_PL_WID)?;
-        if self._buf[1] > 32 {
+        if self.buf[1] > 32 {
             return Err(Nrf24Error::BinaryCorruption);
         }
-        Ok(self._buf[1])
+        Ok(self.buf[1])
     }
 }
 

--- a/crates/rf24-rs/src/radio/rf24/payload_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/payload_length.rs
@@ -9,9 +9,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type PayloadLengthErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn set_payload_length(&mut self, length: u8) -> Result<(), Self::PayloadLengthErrorType> {
+    fn set_payload_length(&mut self, length: u8) -> Result<(), Self::Error> {
         let len = length.clamp(1, 32);
         for i in 0..6 {
             self.spi_write_byte(registers::RX_PW_P0 + i, len)?;
@@ -20,12 +18,12 @@ where
         Ok(())
     }
 
-    fn get_payload_length(&mut self) -> Result<u8, Self::PayloadLengthErrorType> {
+    fn get_payload_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::RX_PW_P0)?;
         Ok(self._buf[1])
     }
 
-    fn set_dynamic_payloads(&mut self, enable: bool) -> Result<(), Self::PayloadLengthErrorType> {
+    fn set_dynamic_payloads(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_read(1, registers::FEATURE)?;
         self._feature =
             Feature::from_bits(self._feature.into_bits() & !Feature::REG_MASK | self._buf[1])
@@ -42,7 +40,7 @@ where
         self._feature.dynamic_payloads()
     }
 
-    fn get_dynamic_payload_length(&mut self) -> Result<u8, Self::PayloadLengthErrorType> {
+    fn get_dynamic_payload_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, commands::R_RX_PL_WID)?;
         if self._buf[1] > 32 {
             return Err(Nrf24Error::BinaryCorruption);

--- a/crates/rf24-rs/src/radio/rf24/pipe.rs
+++ b/crates/rf24-rs/src/radio/rf24/pipe.rs
@@ -1,6 +1,6 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
-use crate::radio::{prelude::EsbPipe, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbPipe, RF24};
 
 use super::registers;
 
@@ -10,9 +10,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type PipeErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn open_rx_pipe(&mut self, pipe: u8, address: &[u8]) -> Result<(), Self::PipeErrorType> {
+    fn open_rx_pipe(&mut self, pipe: u8, address: &[u8]) -> Result<(), Self::Error> {
         if pipe > 5 {
             return Ok(());
         }
@@ -42,13 +40,13 @@ where
         self.spi_write_byte(registers::EN_RXADDR, out)
     }
 
-    fn open_tx_pipe(&mut self, address: &[u8]) -> Result<(), Self::PipeErrorType> {
+    fn open_tx_pipe(&mut self, address: &[u8]) -> Result<(), Self::Error> {
         self.spi_write_buf(registers::TX_ADDR, address)?;
         self.spi_write_buf(registers::RX_ADDR_P0, address)
     }
 
     /// If the given `pipe` number is  not in range [0, 5], then this function does nothing.
-    fn close_rx_pipe(&mut self, pipe: u8) -> Result<(), Self::PipeErrorType> {
+    fn close_rx_pipe(&mut self, pipe: u8) -> Result<(), Self::Error> {
         if pipe > 5 {
             return Ok(());
         }
@@ -61,14 +59,14 @@ where
         Ok(())
     }
 
-    fn set_address_length(&mut self, length: u8) -> Result<(), Self::PipeErrorType> {
+    fn set_address_length(&mut self, length: u8) -> Result<(), Self::Error> {
         let width = length.clamp(2, 5);
         self.spi_write_byte(registers::SETUP_AW, width - 2)?;
         self._feature.set_address_length(width);
         Ok(())
     }
 
-    fn get_address_length(&mut self) -> Result<u8, Self::PipeErrorType> {
+    fn get_address_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::SETUP_AW)?;
         let addr_length = self._buf[1].min(0xFD) + 2;
         self._feature.set_address_length(addr_length);

--- a/crates/rf24-rs/src/radio/rf24/power.rs
+++ b/crates/rf24-rs/src/radio/rf24/power.rs
@@ -25,18 +25,18 @@ where
     /// 900nA (.0009mA).
     fn power_down(&mut self) -> Result<(), Self::Error> {
         self.ce_pin.set_low().map_err(|e| e.kind())?; // Guarantee CE is low on powerDown
-        self._config_reg = self._config_reg.with_power(false);
-        self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())?;
+        self.config_reg = self.config_reg.with_power(false);
+        self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())?;
         Ok(())
     }
 
     fn power_up(&mut self, delay: Option<u32>) -> Result<(), Self::Error> {
         // if not powered up then power up and wait for the radio to initialize
-        if self._config_reg.power() {
+        if self.config_reg.power() {
             return Ok(());
         }
-        self._config_reg = self._config_reg.with_power(true);
-        self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())?;
+        self.config_reg = self.config_reg.with_power(true);
+        self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())?;
 
         // For nRF24L01+ to go from power down mode to TX or RX mode it must first pass through stand-by mode.
         // There must be a delay of Tpd2standby (see Table 16.) after the nRF24L01+ leaves power down mode before
@@ -44,17 +44,17 @@ where
         match delay {
             Some(d) => {
                 if d > 0 {
-                    self._delay_impl.delay_us(d);
+                    self.delay_impl.delay_us(d);
                 }
             }
-            None => self._delay_impl.delay_us(5000),
+            None => self.delay_impl.delay_us(5000),
         }
         Ok(())
     }
 
     /// Is the radio powered up?
     fn is_powered(&self) -> bool {
-        self._config_reg.power()
+        self.config_reg.power()
     }
 }
 

--- a/crates/rf24-rs/src/radio/rf24/radio.rs
+++ b/crates/rf24-rs/src/radio/rf24/radio.rs
@@ -258,7 +258,7 @@ mod test {
                 vec![registers::STATUS | commands::W_REGISTER, 0x70u8],
                 vec![0xEu8, 0u8],
             ),
-            // write cached _pipe0_rx_addr
+            // write cached pipe0_rx_addr
             (buf_expected.to_vec(), vec![0xEu8, 0u8, 0u8, 0u8, 0u8, 0u8]),
         ];
         let mocks = mk_radio(&ce_expectations, &spi_expectations);

--- a/crates/rf24-rs/src/radio/rf24/status.rs
+++ b/crates/rf24-rs/src/radio/rf24/status.rs
@@ -15,10 +15,10 @@ where
 {
     fn set_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
-        self._config_reg = Config::from_bits(
-            self._buf[1] & !StatusFlags::IRQ_MASK | (!flags.into_bits() & StatusFlags::IRQ_MASK),
+        self.config_reg = Config::from_bits(
+            self.buf[1] & !StatusFlags::IRQ_MASK | (!flags.into_bits() & StatusFlags::IRQ_MASK),
         );
-        self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())
+        self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())
     }
 
     fn clear_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::Error> {
@@ -30,7 +30,7 @@ where
     }
 
     fn get_status_flags(&self, flags: &mut StatusFlags) {
-        *flags = self._status;
+        *flags = self.status;
     }
 }
 

--- a/crates/rf24-rs/src/radio/rf24/status.rs
+++ b/crates/rf24-rs/src/radio/rf24/status.rs
@@ -1,7 +1,7 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
 use crate::{
-    radio::{prelude::EsbStatus, Nrf24Error, RF24},
+    radio::{prelude::EsbStatus, RF24},
     types::StatusFlags,
 };
 
@@ -13,9 +13,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type StatusErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn set_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::StatusErrorType> {
+    fn set_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
         self._config_reg = Config::from_bits(
             self._buf[1] & !StatusFlags::IRQ_MASK | (!flags.into_bits() & StatusFlags::IRQ_MASK),
@@ -23,11 +21,11 @@ where
         self.spi_write_byte(registers::CONFIG, self._config_reg.into_bits())
     }
 
-    fn clear_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::StatusErrorType> {
+    fn clear_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::STATUS, flags.into_bits() & StatusFlags::IRQ_MASK)
     }
 
-    fn update(&mut self) -> Result<(), Self::StatusErrorType> {
+    fn update(&mut self) -> Result<(), Self::Error> {
         self.spi_read(0, commands::NOP)
     }
 

--- a/crates/rf24ble-rs/src/radio.rs
+++ b/crates/rf24ble-rs/src/radio.rs
@@ -2,7 +2,11 @@ use crate::{
     data_manipulation::{crc24_ble, reverse_bits, whiten},
     services::BlePayload,
 };
-use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
+use embedded_hal::{
+    delay::DelayNs,
+    digital::{ErrorKind as OutputPinError, OutputPin},
+    spi::{ErrorKind as SpiError, SpiDevice},
+};
 use rf24::{
     radio::{
         prelude::{EsbChannel, EsbPaLevel, EsbRadio},
@@ -183,7 +187,7 @@ impl FakeBle {
     pub fn hop_channel<SPI, DO, DELAY>(
         &self,
         radio: &mut RF24<SPI, DO, DELAY>,
-    ) -> Result<(), Nrf24Error<SPI::Error, DO::Error>>
+    ) -> Result<(), Nrf24Error<SpiError, OutputPinError>>
     where
         SPI: SpiDevice,
         DO: OutputPin,
@@ -284,7 +288,7 @@ impl FakeBle {
         &self,
         radio: &mut RF24<SPI, DO, DELAY>,
         buf: &[u8],
-    ) -> Result<bool, Nrf24Error<SPI::Error, DO::Error>>
+    ) -> Result<bool, Nrf24Error<SpiError, OutputPinError>>
     where
         SPI: SpiDevice,
         DO: OutputPin,
@@ -325,7 +329,7 @@ impl FakeBle {
     pub fn read<SPI, DO, DELAY>(
         &self,
         radio: &mut RF24<SPI, DO, DELAY>,
-    ) -> Result<Option<BlePayload>, Nrf24Error<SPI::Error, DO::Error>>
+    ) -> Result<Option<BlePayload>, Nrf24Error<SpiError, OutputPinError>>
     where
         SPI: SpiDevice,
         DO: OutputPin,


### PR DESCRIPTION
## Concrete Error type
Changes the `Esb*` traits to require a new trait `RadioErrorType`. 
https://github.com/nRF24/rf24-rs/blob/da36293631801e8e089607edd1977129655355c9/crates/rf24-rs/src/radio/prelude.rs#L457

In the `RadioErrorType` trait, there is an associated `Error` type.

https://github.com/nRF24/rf24-rs/blob/da36293631801e8e089607edd1977129655355c9/crates/rf24-rs/src/radio/prelude.rs#L15-L18
Then, the `RadioErrorType` trait is implemented for the `RF24` struct.
https://github.com/nRF24/rf24-rs/blob/da36293631801e8e089607edd1977129655355c9/crates/rf24-rs/src/radio/rf24/mod.rs#L59-L66

### Subsequent required implementations
[The `?` operator](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator) used to [propagate `Result::Err`](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#propagating-errors) needed an explicit forwarding mechanism for hardware-related errors, namely [`embedded_hal::digital::ErrorKind as OutputPinError` and `embedded_hal::spi::ErrorKind as SpiError`](https://github.com/nRF24/rf24-rs/blob/da36293631801e8e089607edd1977129655355c9/crates/rf24-rs/src/radio/rf24/mod.rs#L3-L4).

https://github.com/nRF24/rf24-rs/blob/da36293631801e8e089607edd1977129655355c9/crates/rf24-rs/src/radio/rf24/mod.rs#L47-L57

This allows automatic categorization of the error encountered using our [`Nrf24Error` enum](https://github.com/nRF24/rf24-rs/blob/da36293631801e8e089607edd1977129655355c9/crates/rf24-rs/src/radio/rf24/mod.rs#L33).

### Advantages
This convoluted approach
- allows the radio implementation to choose their own error type (useful if/when I get around to implementing ESB API on nRF5x chips).
- better prepares for implementing the network layers since only the radio type needs to be known at compile time.
- provides better error messages when debugging panics
- unifies the error type returned by various `Esb*` traits' fallible functions. Previously, each trait had it's own associated error type which didn't bode well for implementing different radio hardware. 

## Cached TX address
For the TX address bug, see nRF24/RF24#1028 (and corresponding solution in nRF24/RF24#1029).

## Renamed private fields
Field and variable names prefixed with `_` tells the rust linter ("clippy" tool) that unused dead code shall be explicitly ignored. This does not bode well for static analysis on production code.

Coming from Arduino, this isn't the case. Arduino lib convention suggests to prefix private members with a `_` for readability. Many C++ linters don't treat the `_` prefix of member/variable/parameter names in any special way (excluding `#include` guards).