### PR TITLE
refactor: use concrete error type

### DIFF
--- a/crates/rf24-rs/Cargo.toml
+++ b/crates/rf24-rs/Cargo.toml
@@ -20,7 +20,7 @@ defmt = {version = "1.0.1", optional = true}
 embedded-hal = "1.0.0"
 
 [dev-dependencies]
-embedded-hal-mock = "0.11.1"
+embedded-hal-mock = {git = "https://github.com/2bndy5/embedded-hal-mock.git", branch = "dev"}
 
 [features]
 defmt = ["dep:defmt"]

--- a/crates/rf24-rs/src/radio/rf24/auto_ack.rs
+++ b/crates/rf24-rs/src/radio/rf24/auto_ack.rs
@@ -1,6 +1,6 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
-use crate::radio::{prelude::EsbAutoAck, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbAutoAck, RF24};
 
 use super::{commands, registers, Feature};
 
@@ -10,9 +10,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type AutoAckErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn set_ack_payloads(&mut self, enable: bool) -> Result<(), Self::AutoAckErrorType> {
+    fn set_ack_payloads(&mut self, enable: bool) -> Result<(), Self::Error> {
         if self.feature.ack_payloads() != enable {
             self.spi_read(1, registers::FEATURE)?;
             self.feature =
@@ -36,7 +34,7 @@ where
         self.feature.ack_payloads()
     }
 
-    fn set_auto_ack(&mut self, enable: bool) -> Result<(), Self::AutoAckErrorType> {
+    fn set_auto_ack(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::EN_AA, 0x3F * enable as u8)?;
         // accommodate ACK payloads feature
         if !enable && self.feature.ack_payloads() {
@@ -45,7 +43,7 @@ where
         Ok(())
     }
 
-    fn set_auto_ack_pipe(&mut self, enable: bool, pipe: u8) -> Result<(), Self::AutoAckErrorType> {
+    fn set_auto_ack_pipe(&mut self, enable: bool, pipe: u8) -> Result<(), Self::Error> {
         if pipe > 5 {
             return Ok(());
         }
@@ -58,12 +56,12 @@ where
         self.spi_write_byte(registers::EN_AA, reg_val & !mask | (mask * enable as u8))
     }
 
-    fn allow_ask_no_ack(&mut self, enable: bool) -> Result<(), Self::AutoAckErrorType> {
+    fn allow_ask_no_ack(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_read(1, registers::FEATURE)?;
         self.spi_write_byte(registers::FEATURE, self.buf[1] & !1 | enable as u8)
     }
 
-    fn write_ack_payload(&mut self, pipe: u8, buf: &[u8]) -> Result<bool, Self::AutoAckErrorType> {
+    fn write_ack_payload(&mut self, pipe: u8, buf: &[u8]) -> Result<bool, Self::Error> {
         if self.feature.ack_payloads() && pipe <= 5 {
             let len = buf.len().min(32);
             self.spi_write_buf(commands::W_ACK_PAYLOAD | pipe, &buf[..len])?;
@@ -72,7 +70,7 @@ where
         Ok(false)
     }
 
-    fn set_auto_retries(&mut self, delay: u8, count: u8) -> Result<(), Self::AutoAckErrorType> {
+    fn set_auto_retries(&mut self, delay: u8, count: u8) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::SETUP_RETR, count.min(15) | (delay.min(15) << 4))
     }
 }

--- a/crates/rf24-rs/src/radio/rf24/channel.rs
+++ b/crates/rf24-rs/src/radio/rf24/channel.rs
@@ -1,5 +1,5 @@
 use super::registers;
-use crate::radio::{prelude::EsbChannel, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbChannel, RF24};
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
 impl<SPI, DO, DELAY> EsbChannel for RF24<SPI, DO, DELAY>
@@ -8,16 +8,14 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type ChannelErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     /// The nRF24L01 support 126 channels. The specified `channel` is
     /// clamped to the range [0, 125].
-    fn set_channel(&mut self, channel: u8) -> Result<(), Self::ChannelErrorType> {
+    fn set_channel(&mut self, channel: u8) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::RF_CH, channel.min(125))
     }
 
     /// See also [`RF24::set_channel()`].
-    fn get_channel(&mut self) -> Result<u8, Self::ChannelErrorType> {
+    fn get_channel(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::RF_CH)?;
         Ok(self.buf[1])
     }

--- a/crates/rf24-rs/src/radio/rf24/crc_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/crc_length.rs
@@ -10,9 +10,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type CrcLengthErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn get_crc_length(&mut self) -> Result<CrcLength, Self::CrcLengthErrorType> {
+    fn get_crc_length(&mut self) -> Result<CrcLength, Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
         if self.buf[1] & ConfigReg::CRC_MASK == 4 {
             return Err(Nrf24Error::BinaryCorruption);
@@ -21,7 +19,7 @@ where
         Ok(self.config_reg.crc_length())
     }
 
-    fn set_crc_length(&mut self, crc_length: CrcLength) -> Result<(), Self::CrcLengthErrorType> {
+    fn set_crc_length(&mut self, crc_length: CrcLength) -> Result<(), Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
         self.config_reg = self.config_reg.with_crc_length(crc_length);
         self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())

--- a/crates/rf24-rs/src/radio/rf24/data_rate.rs
+++ b/crates/rf24-rs/src/radio/rf24/data_rate.rs
@@ -21,9 +21,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type DataRateErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn get_data_rate(&mut self) -> Result<DataRate, Self::DataRateErrorType> {
+    fn get_data_rate(&mut self) -> Result<DataRate, Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
         let da_bin = self.buf[1] & DataRate::MASK;
         if da_bin == DataRate::MASK {
@@ -32,7 +30,7 @@ where
         Ok(DataRate::from_bits(da_bin))
     }
 
-    fn set_data_rate(&mut self, data_rate: DataRate) -> Result<(), Self::DataRateErrorType> {
+    fn set_data_rate(&mut self, data_rate: DataRate) -> Result<(), Self::Error> {
         self.tx_delay = set_tx_delay(data_rate);
         self.spi_read(1, registers::RF_SETUP)?;
         let da_bin = data_rate.into_bits();

--- a/crates/rf24-rs/src/radio/rf24/details.rs
+++ b/crates/rf24-rs/src/radio/rf24/details.rs
@@ -1,4 +1,4 @@
-use super::{Nrf24Error, RF24};
+use super::RF24;
 use crate::radio::prelude::EsbDetails;
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
@@ -18,11 +18,9 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type DetailsErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     #[cfg(feature = "defmt")]
     #[cfg(target_os = "none")]
-    fn print_details(&mut self) -> Result<(), Self::DetailsErrorType> {
+    fn print_details(&mut self) -> Result<(), Self::Error> {
         defmt::println!("Is a plus variant_________{=bool}", self.is_plus_variant());
 
         let channel = self.get_channel()?;
@@ -157,13 +155,13 @@ where
     }
 
     #[cfg(not(any(feature = "defmt", feature = "std")))]
-    fn print_details(&mut self) -> Result<(), Self::DetailsErrorType> {
+    fn print_details(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
 
     #[cfg(not(target_os = "none"))]
     #[cfg(feature = "std")]
-    fn print_details(&mut self) -> Result<(), Self::DetailsErrorType> {
+    fn print_details(&mut self) -> Result<(), Self::Error> {
         use crate::radio::rf24::ConfigReg;
 
         std::println!("Is a plus variant_________{}", self.is_plus_variant());

--- a/crates/rf24-rs/src/radio/rf24/fifo.rs
+++ b/crates/rf24-rs/src/radio/rf24/fifo.rs
@@ -1,9 +1,9 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
-use crate::radio::{prelude::EsbFifo, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbFifo, RF24};
 use crate::FifoState;
 
-use super::{commands, registers};
+use super::{commands, registers, Nrf24Error};
 
 impl<SPI, DO, DELAY> EsbFifo for RF24<SPI, DO, DELAY>
 where
@@ -11,14 +11,12 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type FifoErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn available(&mut self) -> Result<bool, Self::FifoErrorType> {
+    fn available(&mut self) -> Result<bool, Self::Error> {
         self.spi_read(1, registers::FIFO_STATUS)?;
         Ok(self.buf[1] & 1 == 0)
     }
 
-    fn available_pipe(&mut self, pipe: &mut u8) -> Result<bool, Self::FifoErrorType> {
+    fn available_pipe(&mut self, pipe: &mut u8) -> Result<bool, Self::Error> {
         if self.available()? {
             // RX FIFO is not empty
             // get last used pipe
@@ -30,23 +28,24 @@ where
     }
 
     /// Use this to discard all 3 layers in the radio's RX FIFO.
-    fn flush_rx(&mut self) -> Result<(), Self::FifoErrorType> {
+    fn flush_rx(&mut self) -> Result<(), Self::Error> {
         self.spi_read(0, commands::FLUSH_RX)
     }
 
     /// Use this to discard all 3 layers in the radio's TX FIFO.
-    fn flush_tx(&mut self) -> Result<(), Self::FifoErrorType> {
+    fn flush_tx(&mut self) -> Result<(), Self::Error> {
         self.spi_read(0, commands::FLUSH_TX)
     }
 
-    fn get_fifo_state(&mut self, about_tx: bool) -> Result<FifoState, Self::FifoErrorType> {
+    fn get_fifo_state(&mut self, about_tx: bool) -> Result<FifoState, Self::Error> {
         self.spi_read(1, registers::FIFO_STATUS)?;
         let offset = about_tx as u8 * 4;
         let status = (self.buf[1] & (3 << offset)) >> offset;
         match status {
+            0 => Ok(FifoState::Occupied),
             1 => Ok(FifoState::Empty),
             2 => Ok(FifoState::Full),
-            _ => Ok(FifoState::Occupied),
+            _ => Err(Nrf24Error::BinaryCorruption),
         }
     }
 }
@@ -56,7 +55,7 @@ where
 #[cfg(test)]
 mod test {
     extern crate std;
-    use super::{commands, registers, EsbFifo, FifoState};
+    use super::{commands, registers, EsbFifo, FifoState, Nrf24Error};
     use crate::{spi_test_expects, test::mk_radio};
     use embedded_hal_mock::eh1::spi::Transaction as SpiTransaction;
     use std::vec;
@@ -102,17 +101,19 @@ mod test {
     pub fn get_fifo_state() {
         let spi_expectations = spi_test_expects![
             // read FIFO register value with empty TX FIFO_STATUS
-            (vec![registers::FIFO_STATUS, 0u8], vec![0xEu8, 0x10u8]),
+            (vec![registers::FIFO_STATUS, 0], vec![0xEu8, 0x10]),
             // read FIFO register value with full TX FIFO_STATUS
-            (vec![registers::FIFO_STATUS, 0x10u8], vec![0xEu8, 0x20u8]),
+            (vec![registers::FIFO_STATUS, 0x10], vec![0xEu8, 0x20]),
             // read FIFO register value with occupied TX FIFO_STATUS
-            (vec![registers::FIFO_STATUS, 0x20u8], vec![0xEu8, 0u8]),
+            (vec![registers::FIFO_STATUS, 0x20], vec![0xEu8, 0]),
             // read FIFO register value with empty RX FIFO_STATUS
-            (vec![registers::FIFO_STATUS, 0u8], vec![0xEu8, 1u8]),
+            (vec![registers::FIFO_STATUS, 0], vec![0xEu8, 1]),
             // read FIFO register value with full RX FIFO_STATUS
-            (vec![registers::FIFO_STATUS, 1u8], vec![0xEu8, 2u8]),
+            (vec![registers::FIFO_STATUS, 1], vec![0xEu8, 2]),
             // read FIFO register value with occupied RX FIFO_STATUS
-            (vec![registers::FIFO_STATUS, 2u8], vec![0xEu8, 0u8]),
+            (vec![registers::FIFO_STATUS, 2], vec![0xEu8, 0]),
+            // read FIFO register value with binary corruption
+            (vec![registers::FIFO_STATUS, 0], vec![0xEu8, 3]),
         ];
         let mocks = mk_radio(&[], &spi_expectations);
         let (mut radio, mut spi, mut ce_pin) = (mocks.0, mocks.1, mocks.2);
@@ -122,6 +123,10 @@ mod test {
         assert_eq!(radio.get_fifo_state(false), Ok(FifoState::Empty));
         assert_eq!(radio.get_fifo_state(false), Ok(FifoState::Full));
         assert_eq!(radio.get_fifo_state(false), Ok(FifoState::Occupied));
+        assert_eq!(
+            radio.get_fifo_state(false),
+            Err(Nrf24Error::BinaryCorruption)
+        );
         spi.done();
         ce_pin.done();
     }

--- a/crates/rf24-rs/src/radio/rf24/init.rs
+++ b/crates/rf24-rs/src/radio/rf24/init.rs
@@ -14,11 +14,9 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type ConfigErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     /// Initialize the radio's hardware using the [`SpiDevice`] and [`OutputPin`] given
     /// to [`RF24::new()`].
-    fn init(&mut self) -> Result<(), Self::ConfigErrorType> {
+    fn init(&mut self) -> Result<(), Self::Error> {
         // Must allow the radio time to settle else configuration bits will not necessarily stick.
         // This is actually only required following power up but some settling time also appears to
         // be required after resets too. For full coverage, we'll always assume the worst.
@@ -49,7 +47,7 @@ where
         self.with_config(&RadioConfig::default())
     }
 
-    fn with_config(&mut self, config: &RadioConfig) -> Result<(), Self::ConfigErrorType> {
+    fn with_config(&mut self, config: &RadioConfig) -> Result<(), Self::Error> {
         self.clear_status_flags(StatusFlags::new())?;
         self.power_down()?;
 

--- a/crates/rf24-rs/src/radio/rf24/mod.rs
+++ b/crates/rf24-rs/src/radio/rf24/mod.rs
@@ -1,4 +1,8 @@
-use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
+use embedded_hal::{
+    delay::DelayNs,
+    digital::{Error as _, ErrorKind as OutputPinError, OutputPin},
+    spi::{Error as _, ErrorKind as SpiError, SpiDevice},
+};
 mod auto_ack;
 pub(crate) mod bit_fields;
 mod channel;
@@ -17,7 +21,7 @@ pub use constants::{commands, mnemonics, registers};
 mod details;
 mod status;
 use super::prelude::{
-    EsbAutoAck, EsbChannel, EsbCrcLength, EsbFifo, EsbPaLevel, EsbPower, EsbRadio,
+    EsbAutoAck, EsbChannel, EsbCrcLength, EsbFifo, EsbPaLevel, EsbPower, EsbRadio, RadioErrorType,
 };
 use crate::{
     types::{CrcLength, PaLevel},
@@ -38,6 +42,27 @@ pub enum Nrf24Error<SPI, DO> {
     /// This only occurs when user code neglected to call [`RF24::as_tx()`] at least once
     /// before calling [`RF24::send()`].
     NotAsTxError,
+}
+
+impl From<SpiError> for Nrf24Error<SpiError, OutputPinError> {
+    fn from(value: SpiError) -> Self {
+        Nrf24Error::Spi(value)
+    }
+}
+
+impl From<OutputPinError> for Nrf24Error<SpiError, OutputPinError> {
+    fn from(value: OutputPinError) -> Self {
+        Nrf24Error::Gpo(value)
+    }
+}
+
+impl<SPI, DO, DELAY> RadioErrorType for RF24<SPI, DO, DELAY>
+where
+    SPI: SpiDevice,
+    DO: OutputPin,
+    DELAY: DelayNs,
+{
+    type Error = Nrf24Error<SpiError, OutputPinError>;
 }
 
 /// This struct implements the [`Esb*` traits](mod@crate::radio::prelude)
@@ -113,10 +138,10 @@ where
         }
     }
 
-    fn spi_transfer(&mut self, len: u8) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    fn spi_transfer(&mut self, len: u8) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.spi
             .transfer_in_place(&mut self.buf[..len as usize])
-            .map_err(Nrf24Error::Spi)?;
+            .map_err(|e| e.kind())?;
         self.status = StatusFlags::from_bits(self.buf[0]);
         Ok(())
     }
@@ -126,7 +151,11 @@ where
     /// self.spi_read(0, commands::NOP)?;
     /// // STATUS register is now stored in self._status
     /// ```
-    fn spi_read(&mut self, len: u8, command: u8) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    fn spi_read(
+        &mut self,
+        len: u8,
+        command: u8,
+    ) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.buf[0] = command;
         self.spi_transfer(len + 1)
     }
@@ -135,7 +164,7 @@ where
         &mut self,
         command: u8,
         byte: u8,
-    ) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    ) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.buf[0] = command | commands::W_REGISTER;
         self.buf[1] = byte;
         self.spi_transfer(2)
@@ -145,7 +174,7 @@ where
         &mut self,
         command: u8,
         buf: &[u8],
-    ) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    ) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.buf[0] = command | commands::W_REGISTER;
         let buf_len = buf.len();
         self.buf[1..(buf_len + 1)].copy_from_slice(&buf[..buf_len]);
@@ -154,7 +183,7 @@ where
 
     /// A private function to write a special SPI command specific to older
     /// non-plus variants of the nRF24L01 radio module. It has no effect on plus variants.
-    fn toggle_features(&mut self) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    fn toggle_features(&mut self) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.buf[0] = commands::ACTIVATE;
         self.buf[1] = 0x73;
         self.spi_transfer(2)
@@ -168,7 +197,7 @@ where
         self.feature.is_plus_variant()
     }
 
-    pub fn rpd(&mut self) -> Result<bool, Nrf24Error<SPI::Error, DO::Error>> {
+    pub fn rpd(&mut self) -> Result<bool, Nrf24Error<SpiError, OutputPinError>> {
         self.spi_read(1, registers::RPD)?;
         Ok(self.buf[1] & 1 == 1)
     }
@@ -177,7 +206,7 @@ where
         &mut self,
         level: PaLevel,
         channel: u8,
-    ) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    ) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.as_tx()?;
         self.spi_read(1, registers::RF_SETUP)?;
         self.spi_write_byte(registers::RF_SETUP, self.buf[1] | 0x90)?;
@@ -197,7 +226,7 @@ where
         }
         self.set_pa_level(level)?;
         self.set_channel(channel)?;
-        self.ce_pin.set_high().map_err(Nrf24Error::Gpo)?;
+        self.ce_pin.set_high().map_err(|e| e.kind())?;
         if self.feature.is_plus_variant() {
             self.delay_impl.delay_ns(1000000); // datasheet says 1 ms is ok in this instance
             self.rewrite()?;
@@ -205,7 +234,7 @@ where
         Ok(())
     }
 
-    pub fn stop_carrier_wave(&mut self) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    pub fn stop_carrier_wave(&mut self) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         /*
          * A note from the datasheet:
          * Do not use REUSE_TX_PL together with CONT_WAVE=1. When both these
@@ -215,7 +244,8 @@ where
         self.power_down()?; // per datasheet recommendation (just to be safe)
         self.spi_read(1, registers::RF_SETUP)?;
         self.spi_write_byte(registers::RF_SETUP, self.buf[1] & !0x90)?;
-        self.ce_pin.set_low().map_err(Nrf24Error::Gpo)
+        self.ce_pin.set_low().map_err(|e| e.kind())?;
+        Ok(())
     }
 
     /// Control the builtin LNA feature on nRF24L01 (older non-plus variants) and Si24R1
@@ -226,7 +256,7 @@ where
     ///
     /// This function has no effect on nRF24L01+ modules and PA/LNA variants because
     /// the LNA feature is always enabled.
-    pub fn set_lna(&mut self, enable: bool) -> Result<(), Nrf24Error<SPI::Error, DO::Error>> {
+    pub fn set_lna(&mut self, enable: bool) -> Result<(), Nrf24Error<SpiError, OutputPinError>> {
         self.spi_read(1, registers::RF_SETUP)?;
         let out = self.buf[1] & !1 | enable as u8;
         self.spi_write_byte(registers::RF_SETUP, out)

--- a/crates/rf24-rs/src/radio/rf24/pa_level.rs
+++ b/crates/rf24-rs/src/radio/rf24/pa_level.rs
@@ -1,7 +1,7 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
 use super::registers;
-use crate::radio::{prelude::EsbPaLevel, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbPaLevel, RF24};
 use crate::PaLevel;
 
 impl<SPI, DO, DELAY> EsbPaLevel for RF24<SPI, DO, DELAY>
@@ -10,14 +10,12 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type PaLevelErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn get_pa_level(&mut self) -> Result<PaLevel, Self::PaLevelErrorType> {
+    fn get_pa_level(&mut self) -> Result<PaLevel, Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
         Ok(PaLevel::from_bits(self.buf[1] & PaLevel::MASK))
     }
 
-    fn set_pa_level(&mut self, pa_level: PaLevel) -> Result<(), Self::PaLevelErrorType> {
+    fn set_pa_level(&mut self, pa_level: PaLevel) -> Result<(), Self::Error> {
         self.spi_read(1, registers::RF_SETUP)?;
         let out = self.buf[1] & !PaLevel::MASK | pa_level.into_bits();
         self.spi_write_byte(registers::RF_SETUP, out)

--- a/crates/rf24-rs/src/radio/rf24/payload_length.rs
+++ b/crates/rf24-rs/src/radio/rf24/payload_length.rs
@@ -9,9 +9,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type PayloadLengthErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn set_payload_length(&mut self, length: u8) -> Result<(), Self::PayloadLengthErrorType> {
+    fn set_payload_length(&mut self, length: u8) -> Result<(), Self::Error> {
         let len = length.clamp(1, 32);
         for i in 0..6 {
             self.spi_write_byte(registers::RX_PW_P0 + i, len)?;
@@ -20,12 +18,12 @@ where
         Ok(())
     }
 
-    fn get_payload_length(&mut self) -> Result<u8, Self::PayloadLengthErrorType> {
+    fn get_payload_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, registers::RX_PW_P0)?;
         Ok(self.buf[1])
     }
 
-    fn set_dynamic_payloads(&mut self, enable: bool) -> Result<(), Self::PayloadLengthErrorType> {
+    fn set_dynamic_payloads(&mut self, enable: bool) -> Result<(), Self::Error> {
         self.spi_read(1, registers::FEATURE)?;
         self.feature =
             Feature::from_bits(self.feature.into_bits() & !Feature::REG_MASK | self.buf[1])
@@ -42,7 +40,7 @@ where
         self.feature.dynamic_payloads()
     }
 
-    fn get_dynamic_payload_length(&mut self) -> Result<u8, Self::PayloadLengthErrorType> {
+    fn get_dynamic_payload_length(&mut self) -> Result<u8, Self::Error> {
         self.spi_read(1, commands::R_RX_PL_WID)?;
         if self.buf[1] > 32 {
             return Err(Nrf24Error::BinaryCorruption);

--- a/crates/rf24-rs/src/radio/rf24/power.rs
+++ b/crates/rf24-rs/src/radio/rf24/power.rs
@@ -1,6 +1,10 @@
-use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
+use embedded_hal::{
+    delay::DelayNs,
+    digital::{Error, OutputPin},
+    spi::SpiDevice,
+};
 
-use crate::radio::{prelude::EsbPower, Nrf24Error, RF24};
+use crate::radio::{prelude::EsbPower, RF24};
 
 use super::registers;
 
@@ -10,8 +14,6 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type PowerErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
     /// After calling [`EsbRadio::as_rx()`](fn@crate::radio::prelude::EsbRadio::as_rx),
     /// a non-PA/LNA radio will consume about
     /// 13.5mA at [`PaLevel::MAX`](type@crate::types::PaLevel::Max).
@@ -21,14 +23,14 @@ where
     /// will consume about 26uA (.026mA).
     /// In full power down mode (a sleep state), the radio will consume approximately
     /// 900nA (.0009mA).
-    fn power_down(&mut self) -> Result<(), Self::PowerErrorType> {
-        self.ce_pin.set_low().map_err(Nrf24Error::Gpo)?; // Guarantee CE is low on powerDown
+    fn power_down(&mut self) -> Result<(), Self::Error> {
+        self.ce_pin.set_low().map_err(|e| e.kind())?; // Guarantee CE is low on powerDown
         self.config_reg = self.config_reg.with_power(false);
         self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())?;
         Ok(())
     }
 
-    fn power_up(&mut self, delay: Option<u32>) -> Result<(), Self::PowerErrorType> {
+    fn power_up(&mut self, delay: Option<u32>) -> Result<(), Self::Error> {
         // if not powered up then power up and wait for the radio to initialize
         if self.config_reg.power() {
             return Ok(());

--- a/crates/rf24-rs/src/radio/rf24/status.rs
+++ b/crates/rf24-rs/src/radio/rf24/status.rs
@@ -1,7 +1,7 @@
 use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
 
 use crate::{
-    radio::{prelude::EsbStatus, Nrf24Error, RF24},
+    radio::{prelude::EsbStatus, RF24},
     types::StatusFlags,
 };
 
@@ -13,9 +13,7 @@ where
     DO: OutputPin,
     DELAY: DelayNs,
 {
-    type StatusErrorType = Nrf24Error<SPI::Error, DO::Error>;
-
-    fn set_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::StatusErrorType> {
+    fn set_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::Error> {
         self.spi_read(1, registers::CONFIG)?;
         self.config_reg = ConfigReg::from_bits(
             self.buf[1] & !StatusFlags::IRQ_MASK | (!flags.into_bits() & StatusFlags::IRQ_MASK),
@@ -23,11 +21,11 @@ where
         self.spi_write_byte(registers::CONFIG, self.config_reg.into_bits())
     }
 
-    fn clear_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::StatusErrorType> {
+    fn clear_status_flags(&mut self, flags: StatusFlags) -> Result<(), Self::Error> {
         self.spi_write_byte(registers::STATUS, flags.into_bits() & StatusFlags::IRQ_MASK)
     }
 
-    fn update(&mut self) -> Result<(), Self::StatusErrorType> {
+    fn update(&mut self) -> Result<(), Self::Error> {
         self.spi_read(0, commands::NOP)
     }
 

--- a/crates/rf24ble-rs/src/radio.rs
+++ b/crates/rf24ble-rs/src/radio.rs
@@ -2,7 +2,11 @@ use crate::{
     data_manipulation::{crc24_ble, reverse_bits, whiten},
     services::BlePayload,
 };
-use embedded_hal::{delay::DelayNs, digital::OutputPin, spi::SpiDevice};
+use embedded_hal::{
+    delay::DelayNs,
+    digital::{ErrorKind as OutputPinError, OutputPin},
+    spi::{ErrorKind as SpiError, SpiDevice},
+};
 use rf24::{
     radio::{
         prelude::{EsbChannel, EsbPaLevel, EsbRadio},
@@ -183,7 +187,7 @@ impl FakeBle {
     pub fn hop_channel<SPI, DO, DELAY>(
         &self,
         radio: &mut RF24<SPI, DO, DELAY>,
-    ) -> Result<(), Nrf24Error<SPI::Error, DO::Error>>
+    ) -> Result<(), Nrf24Error<SpiError, OutputPinError>>
     where
         SPI: SpiDevice,
         DO: OutputPin,
@@ -284,7 +288,7 @@ impl FakeBle {
         &self,
         radio: &mut RF24<SPI, DO, DELAY>,
         buf: &[u8],
-    ) -> Result<bool, Nrf24Error<SPI::Error, DO::Error>>
+    ) -> Result<bool, Nrf24Error<SpiError, OutputPinError>>
     where
         SPI: SpiDevice,
         DO: OutputPin,
@@ -325,7 +329,7 @@ impl FakeBle {
     pub fn read<SPI, DO, DELAY>(
         &self,
         radio: &mut RF24<SPI, DO, DELAY>,
-    ) -> Result<Option<BlePayload>, Nrf24Error<SPI::Error, DO::Error>>
+    ) -> Result<Option<BlePayload>, Nrf24Error<SpiError, OutputPinError>>
     where
         SPI: SpiDevice,
         DO: OutputPin,


### PR DESCRIPTION
## Concrete Error type
Changes the `Esb*` traits to require a new trait `RadioErrorType`. 
https://github.com/nRF24/rf24-rs/blob/da90c7a9aa6a81c17a7b33711086738db722e5f1/crates/rf24-rs/src/radio/prelude.rs#L457

In the `RadioErrorType` trait, there is an associated `Error` type.

https://github.com/nRF24/rf24-rs/blob/da90c7a9aa6a81c17a7b33711086738db722e5f1/crates/rf24-rs/src/radio/prelude.rs#L15-L18
Then, the `RadioErrorType` trait is implemented for the `RF24` struct.
https://github.com/nRF24/rf24-rs/blob/da90c7a9aa6a81c17a7b33711086738db722e5f1/crates/rf24-rs/src/radio/rf24/mod.rs#L59-L66

### Subsequent required implementations
[The `?` operator](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#a-shortcut-for-propagating-errors-the--operator) used to [propagate `Result::Err`](https://doc.rust-lang.org/book/ch09-02-recoverable-errors-with-result.html#propagating-errors) needed an explicit forwarding mechanism for hardware-related errors, namely [`embedded_hal::digital::ErrorKind as OutputPinError` and `embedded_hal::spi::ErrorKind as SpiError`](https://github.com/nRF24/rf24-rs/blob/da90c7a9aa6a81c17a7b33711086738db722e5f1/crates/rf24-rs/src/radio/rf24/mod.rs#L1-L4).

https://github.com/nRF24/rf24-rs/blob/da90c7a9aa6a81c17a7b33711086738db722e5f1/crates/rf24-rs/src/radio/rf24/mod.rs#L47-L57

This allows automatic categorization of the error encountered using our [`Nrf24Error` enum](https://github.com/nRF24/rf24-rs/blob/da90c7a9aa6a81c17a7b33711086738db722e5f1/crates/rf24-rs/src/radio/rf24/mod.rs#L33).

### Advantages
This convoluted approach
- allows the radio implementation to choose their own error type (useful if/when I get around to implementing ESB API on nRF5x chips).
- better prepares for implementing the network layers since only the radio type needs to be known at compile time.
- provides better error messages when debugging panics
- unifies the error type returned by various `Esb*` traits' fallible functions. Previously, each trait had it's own associated error type which didn't bode well for implementing different radio hardware. 

## Using dev branch of embedded-hal-mock fork
There were a few lines about forward error types into our own `Nrf24Error` enum (`impl From<T>` -- see above).
I opened a couple issues to hopefully resolve this upstream in the mock library we're using for unit tests:
- dbrgn/embedded-hal-mock#128
   - resolved by dbrgn/embedded-hal-mock#131
- dbrgn/embedded-hal-mock#129 (would be considered a breaking change though)
   - resolved by dbrgn/embedded-hal-mock#132

For now, I'll be using my fork's dev branch until these patches are accepted and deployed upstream.