### PR TITLE
fix: adjust linting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,6 +49,11 @@ jobs:
         uses: hustcer/setup-nu@v3
         with:
           version: ${{ vars.NU_SHELL_VERSION || '*' }}
+      - name: Cache deps
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo
+          key: cargo-docs-${{ hashFiles('crates/*/src/**', 'crates/**/Cargo.toml') }}
       - run: nu -c "use nurfile *; nur docs rs"
       - name: save docs as artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -33,9 +33,10 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo
-          key: cargo-lib-${{ hashFiles('lib/src/**', 'lib/Cargo.toml') }}
+          key: cargo-lint-${{ hashFiles('**/*.rs') }}
       - run: cargo clippy
-      - run: cargo fmt --check
+      - run: cargo clippy -p examples
+      - run: cargo fmt --check --all
 
   lint-typescript:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cargo
-          key: cargo-lib-${{ hashFiles('crates/*/src/**', 'crates/**/Cargo.toml') }}
+          key: cargo-crates-${{ hashFiles('crates/*/src/**', 'crates/**/Cargo.toml') }}
       - run: rustup component add llvm-tools-preview
         # this enables a tool (for default toolchain) needed to measure code coverage.
       - name: Run tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
     - id: trailing-whitespace
       exclude: .yarn/releases/yarn.*js
@@ -16,7 +16,7 @@ repos:
       args: ['--fix=lf']
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.12.7
+  rev: v0.12.9
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
-members = ["crates/rf24-rs", "examples/rust", "bindings/python", "bindings/node", "crates/rf24ble-rs"]
-default-members = ["crates/rf24-rs", "crates/rf24ble-rs", "examples/rust"]
+members = ["crates/*", "examples/rust", "bindings/*"]
+default-members = ["crates/*", "bindings/*"]
 resolver = "2"
 
 [workspace.package]

--- a/bindings/node/src/radio/interface.rs
+++ b/bindings/node/src/radio/interface.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "linux")]
-
 use std::time::Duration;
 
 use super::config::RadioConfig;

--- a/bindings/node/src/radio/mod.rs
+++ b/bindings/node/src/radio/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
+#[cfg(target_os = "linux")]
 pub mod interface;
 pub mod types;

--- a/bindings/node/src/radio/types.rs
+++ b/bindings/node/src/radio/types.rs
@@ -13,6 +13,10 @@ pub fn coerce_to_bool(napi_instance: Option<JsNumber>, default: bool) -> Result<
 /// Optional configuration parameters to fine tune instantiating the {@link RF24} object.
 /// Pass this object as third parameter to {@link RF24} constructor.
 #[napi(object)]
+#[cfg_attr(
+    not(target_os = "linux"),
+    allow(dead_code, reason = "Constructed only on Linux targets")
+)]
 pub struct HardwareConfig {
     /// The GPIO chip number: `/dev/gpiochipN` where `N` is this value.
     ///
@@ -88,6 +92,7 @@ impl StatusFlags {
 
 /// An optional configuration for {@link RF24.write}
 #[napi(object)]
+#[cfg(target_os = "linux")]
 pub struct WriteConfig {
     /// Set to `true` if you want to disable auto-ACK feature for the individual
     /// payload (required `buf` parameter to {@link RF24.write}).
@@ -106,6 +111,7 @@ pub struct WriteConfig {
     pub start_tx: Option<bool>,
 }
 
+#[cfg(target_os = "linux")]
 impl Default for WriteConfig {
     fn default() -> Self {
         Self {
@@ -117,6 +123,7 @@ impl Default for WriteConfig {
 
 /// The return type for {@link RF24.availablePipe}
 #[napi(object)]
+#[cfg(target_os = "linux")]
 pub struct AvailablePipe {
     /// Is RX data available in the RX FIFO?
     pub available: bool,

--- a/bindings/python/src/fake_ble/radio.rs
+++ b/bindings/python/src/fake_ble/radio.rs
@@ -81,7 +81,7 @@ impl FakeBle {
     }
 
     #[getter]
-    pub fn get_mac_address(&self) -> Cow<[u8]> {
+    pub fn get_mac_address(&'_ self) -> Cow<'_, [u8]> {
         Cow::from(&self.inner.mac_address)
     }
 

--- a/bindings/python/src/fake_ble/services.rs
+++ b/bindings/python/src/fake_ble/services.rs
@@ -36,7 +36,7 @@ impl BatteryService {
 
     /// Transform the service data into a BLE compliant buffer that is ready for broadcasting.
     #[getter]
-    pub fn get_buffer(&mut self) -> Cow<[u8]> {
+    pub fn get_buffer(&'_ mut self) -> Cow<'_, [u8]> {
         Cow::from(self.inner.buffer())
     }
 }
@@ -73,7 +73,7 @@ impl TemperatureService {
 
     /// Transform the service data into a BLE compliant buffer that is ready for broadcasting.
     #[getter]
-    pub fn get_buffer(&self) -> Cow<[u8]> {
+    pub fn get_buffer(&'_ self) -> Cow<'_, [u8]> {
         Cow::from(self.inner.buffer())
     }
 }
@@ -122,7 +122,7 @@ impl UrlService {
 
     /// Transform the service data into a BLE compliant buffer that is ready for broadcasting.
     #[getter]
-    pub fn get_buffer(&self) -> Cow<[u8]> {
+    pub fn get_buffer(&'_ self) -> Cow<'_, [u8]> {
         Cow::from(self.inner.buffer())
     }
 }

--- a/bindings/python/src/radio/config.rs
+++ b/bindings/python/src/radio/config.rs
@@ -304,7 +304,7 @@ impl RadioConfig {
     }
 
     /// Get the address for a specified `pipe` set by [`RadioConfig.set_rx_address()`][rf24_py.RadioConfig.set_rx_address].
-    pub fn get_rx_address(&mut self, pipe: u8) -> Cow<[u8]> {
+    pub fn get_rx_address(&'_ mut self, pipe: u8) -> Cow<'_, [u8]> {
         self.inner.rx_address(pipe, &mut self.addr_buf);
         Cow::from(&self.addr_buf)
     }
@@ -313,7 +313,7 @@ impl RadioConfig {
     ///
     /// Only pipe 0 can be used for TX operations (including auto-ACK packets during RX operations).
     #[getter]
-    pub fn get_tx_address(&mut self) -> Cow<[u8]> {
+    pub fn get_tx_address(&'_ mut self) -> Cow<'_, [u8]> {
         self.inner.tx_address(&mut self.addr_buf);
         Cow::from(&self.addr_buf)
     }

--- a/bindings/python/src/radio/interface.rs
+++ b/bindings/python/src/radio/interface.rs
@@ -1,4 +1,3 @@
-#![cfg(target_os = "linux")]
 use std::borrow::Cow;
 use std::time::Duration;
 
@@ -278,7 +277,7 @@ impl RF24 {
     ///     sized payload or [`RF24.payload_length`][rf24_py.RF24.payload_length] for
     ///     statically sized payloads.
     #[pyo3(signature = (len = None))]
-    pub fn read(&mut self, len: Option<u8>) -> PyResult<Cow<[u8]>> {
+    pub fn read(&'_ mut self, len: Option<u8>) -> PyResult<Cow<'_, [u8]>> {
         let len = self
             .inner
             .read(&mut self.read_buf, len)

--- a/bindings/python/src/radio/mod.rs
+++ b/bindings/python/src/radio/mod.rs
@@ -1,3 +1,4 @@
 pub mod config;
+#[cfg(target_os = "linux")]
 pub mod interface;
 pub mod types;

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
-name = "rf24-rs-examples"
+name = "examples"
 version = "0.1.0"
 edition.workspace = true
 default-run = "getting-started"
 
+[lib]
+name = "rf24_rs_examples"
+
 [dependencies]
-rf24-rs = {path = "../../crates/rf24-rs"}
-rf24ble-rs = {path = "../../crates/rf24ble-rs"}
+rf24-rs = {path = "../../crates/rf24-rs", version = "0.3.1"}
+rf24ble-rs = {path = "../../crates/rf24ble-rs", version = "0.1.4"}
 embedded-hal = "1.0.0"
 anyhow = {version = "1.0.98", default-features = false}
 linux-embedded-hal = {version = "0.4.0", optional = true, default-features = false, features = ["gpio_cdev", "spi"]}

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -17,7 +17,7 @@ The sources for each example are located in examples/rust/src/bin/.
 For Linux boards, this can be done simply by executing the command:
 
 ```shell
-cargo run --bin getting-started
+cargo run -p examples --bin getting-started
 ```
 
 The provided examples names (value passed to the `--bin` option) are

--- a/nurfile
+++ b/nurfile
@@ -36,11 +36,12 @@ export def "nur test" [
     if $clean {
         run-cmd cargo llvm-cov clean
     }
-    let cmd = (
-        [cargo llvm-cov --no-report nextest]
-        | append [-p rf24-rs -p rf24ble-rs]
-        | append [--lib --tests --color always --profile $profile]
-    )
+    let excluded = [rf24-node rf24-py examples]
+    mut cmd = [cargo llvm-cov --no-report --workspace]
+    for ex in $excluded {
+        $cmd = $cmd | append [--exclude $ex]
+    }
+    $cmd = $cmd | append [nextest --lib --tests --color always --profile $profile]
     run-cmd ...$cmd
 }
 
@@ -162,14 +163,8 @@ export def "nur docs rs" [
 export def "nur lint" [
     --js, # A flag to lint/format Javascript (and Typescript) sources.
 ] {
-    let common_args = (
-        [-p rf24-rs -p rf24ble-rs -p rf24-node -p rf24-py]
-    )
-    run-cmd ...(
-        [cargo clippy --fix --allow-dirty --allow-staged]
-        | append [...$common_args]
-    )
-    run-cmd ...[cargo fmt ...$common_args]
+    run-cmd cargo clippy --fix --allow-dirty --allow-staged
+    run-cmd cargo fmt
     if ($js) {
         run-cmd yarn lint
         if ("bindings/node/index.d.ts" | path exists) {
@@ -182,8 +177,8 @@ export def "nur lint" [
 
 # Run clippy and rustfmt (on rust examples only).
 export def "nur lint examples" [] {
-    run-cmd cargo clippy -p rf24-rs-examples --fix --allow-dirty --allow-staged
-    run-cmd cargo fmt -p rf24-rs-examples
+    run-cmd cargo clippy -p examples --fix --allow-dirty --allow-staged
+    run-cmd cargo fmt -p examples
 }
 
 # Run pre-commit hooks


### PR DESCRIPTION
## Rust linter (clippy)

A recent update to rust's `clippy` tool triggered several lint violations when not targeting Linux.

Some just required an explicitly anonymous lifetime for member functions that return buffer objects in the bindings.

Others were about unused structs on non-Linux platforms in the node.js binding. The solution for this one was to conditionally compile the structs for only Linux targets. This is not considered a breaking change because the type info remains the same regardless.

## Pre-commit hooks

Updated the pre-commit hooks and ran them

## Metadata

Some metadata changes were made to exclude linting the rust examples by default. This was done because the examples do not compile for all platforms. More attention is still needed on this subject (see #8).

To run the examples (still only on Linux), an extra arg is now required: `-p examples`. So, the command to run the getting-started example is now:
```shell
cargo run -p examples --bin getting-started
```

These metadata changes also incited changes to the nurfile about various command invoked in tasks.

## CI workflows

I adjusted the lint CI workflow to check all rust packages (including examples) in the workspace (this repo).

I reviewed the caching of rust assets, which are only used when linting, testing, or documenting rust libraries.