### PR TITLE
build(deps): bump cargo group with 5 updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ homepage = "https://nRF24.github.io/rf24-rs"
 edition = "2021"
 license = "MIT"
 
+[workspace.dependencies]
+linux-embedded-hal = { version = "0.5.0", default-features = false, features = ["gpio_cdev", "spi"] }
+nix = "0.31.3"
+bitfield-struct = "0.9.5"
+
 [profile.release]
 lto = true
 strip = "symbols"

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -12,13 +12,13 @@ crate-type = ["cdylib"]
 [dependencies]
 embedded-hal = "1.0.0"
 # Default `napi` features: see https://nodejs.org/api/n-api.html#node-api-version-matrix
-napi = "3.3.0"
-napi-derive = "3.2.5"
+napi = "3.5.2"
+napi-derive = "3.3.3"
 rf24-rs = { path = "../../crates/rf24-rs", features = ["std"] }
 rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 
 [build-dependencies]
-napi-build = "2.2.3"
+napi-build = "2.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 linux-embedded-hal = {version = "0.4.1", default-features = false, features = ["gpio_cdev", "spi"]}

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -12,8 +12,8 @@ crate-type = ["cdylib"]
 [dependencies]
 embedded-hal = "1.0.0"
 # Default `napi` features: see https://nodejs.org/api/n-api.html#node-api-version-matrix
-napi = "3.1.3"
-napi-derive = "3.1.1"
+napi = "3.3.0"
+napi-derive = "3.2.5"
 rf24-rs = { path = "../../crates/rf24-rs", features = ["std"] }
 rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 
@@ -21,5 +21,5 @@ rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 napi-build = "2.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-linux-embedded-hal = {version = "0.4.0", default-features = false, features = ["gpio_cdev", "spi"]}
+linux-embedded-hal = {version = "0.4.1", default-features = false, features = ["gpio_cdev", "spi"]}
 nix = { version = "0.30.1", features = ["time"]}

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.3"
 repository.workspace = true
 edition.workspace = true
 license.workspace = true
-rust-version = "1.80"
+rust-version = "1.88"
 
 [lib]
 crate-type = ["cdylib"]

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -12,13 +12,13 @@ crate-type = ["cdylib"]
 [dependencies]
 embedded-hal = "1.0.0"
 # Default `napi` features: see https://nodejs.org/api/n-api.html#node-api-version-matrix
-napi = "3.5.2"
-napi-derive = "3.3.3"
+napi = "3.12.2"
+napi-derive = "3.6.3"
 rf24-rs = { path = "../../crates/rf24-rs", features = ["std"] }
 rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 
 [build-dependencies]
-napi-build = "2.3.1"
+napi-build = "2.4.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 linux-embedded-hal.workspace = true

--- a/bindings/node/Cargo.toml
+++ b/bindings/node/Cargo.toml
@@ -21,5 +21,5 @@ rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 napi-build = "2.3.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-linux-embedded-hal = {version = "0.4.1", default-features = false, features = ["gpio_cdev", "spi"]}
-nix = { version = "0.30.1", features = ["time"]}
+linux-embedded-hal.workspace = true
+nix = { workspace = true, features = ["time"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,10 +14,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 embedded-hal = "1.0.0"
-pyo3 = {version = "0.26.0", features = ["extension-module", "abi3-py39"]}
+pyo3 = {version = "0.27.1", features = ["extension-module", "abi3-py39"]}
 rf24-rs = { path = "../../crates/rf24-rs", features = ["std"]}
 rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-linux-embedded-hal = {version = "0.4.0", default-features = false, features = ["gpio_cdev", "spi"]}
+linux-embedded-hal = {version = "0.4.1", default-features = false, features = ["gpio_cdev", "spi"]}
 nix = { version = "0.30.1", features = ["time"]}

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -19,5 +19,5 @@ rf24-rs = { path = "../../crates/rf24-rs", features = ["std"]}
 rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-linux-embedded-hal = {version = "0.4.1", default-features = false, features = ["gpio_cdev", "spi"]}
-nix = { version = "0.30.1", features = ["time"]}
+linux-embedded-hal.workspace = true
+nix = { workspace = true, features = ["time"] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 embedded-hal = "1.0.0"
-pyo3 = {version = "0.27.1", features = ["extension-module", "abi3-py39"]}
+pyo3 = {version = "0.29.2", features = ["extension-module", "abi3-py39"]}
 rf24-rs = { path = "../../crates/rf24-rs", features = ["std"]}
 rf24ble-rs = { path = "../../crates/rf24ble-rs", features = ["std"] }
 

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -37,7 +37,6 @@ uv sync
 ```
 
 Append `--no-dev` (or set `UV_NO_DEV=1` environment variable) for environments with limited disk space (eg. Raspberry Pi machine).
-As of [uv] v0.8.7, the environment variable
 
 [uv]: https://docs.astral.sh/uv
 

--- a/bindings/python/src/fake_ble/services.rs
+++ b/bindings/python/src/fake_ble/services.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 ///
 /// Conforms to Battery Level format as defined in
 /// [GATT Specifications Supplement](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=502132&vId=542989).
-#[pyclass(module = "rf24_py")]
+#[pyclass(module = "rf24_py", from_py_object)]
 #[derive(Debug, Clone, Copy)]
 pub struct BatteryService {
     inner: rf24ble::services::BatteryService,
@@ -45,7 +45,7 @@ impl BatteryService {
 ///
 /// Conforms to the Health Thermometer Measurement format as defined in
 /// [GATT Specifications Supplement](https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=502132&vId=542989).
-#[pyclass(module = "rf24_py")]
+#[pyclass(module = "rf24_py", from_py_object)]
 #[derive(Debug, Clone, Copy)]
 pub struct TemperatureService {
     inner: rf24ble::services::TemperatureService,
@@ -83,7 +83,7 @@ impl TemperatureService {
 /// Conforms to specifications defined by [Google's EddyStone][eddystone] data format.
 ///
 /// [eddystone]: https://github.com/google/eddystone
-#[pyclass(module = "rf24_py")]
+#[pyclass(module = "rf24_py", from_py_object)]
 #[derive(Debug, Clone, Copy)]
 pub struct UrlService {
     inner: rf24ble::services::UrlService,

--- a/bindings/python/src/radio/config.rs
+++ b/bindings/python/src/radio/config.rs
@@ -40,7 +40,7 @@ use std::borrow::Cow;
 ///
 /// [^1]: The RX address default value is the same as pipe 0 default TX address.
 /// [^2]: Remember, pipes 2 - 5 share the same 4 LSBytes as the address on pipe 1.
-#[pyclass(module = "rf24_py")]
+#[pyclass(module = "rf24_py", from_py_object)]
 #[derive(Debug, Clone, Copy)]
 pub struct RadioConfig {
     inner: rf24::radio::RadioConfig,

--- a/bindings/python/src/radio/types.rs
+++ b/bindings/python/src/radio/types.rs
@@ -187,6 +187,7 @@ pub enum FifoState {
     Occupied,
 }
 
+#[cfg(target_os = "linux")]
 impl FifoState {
     pub fn into_inner(self) -> rf24::FifoState {
         match self {

--- a/bindings/python/src/radio/types.rs
+++ b/bindings/python/src/radio/types.rs
@@ -7,7 +7,7 @@ use pyo3::prelude::*;
 ///     - [`RF24.set_status_flags()`][rf24_py.RF24.set_status_flags]
 ///     - [`RF24.clear_status_flags()`][rf24_py.RF24.clear_status_flags]
 ///     - [`RF24.update()`][rf24_py.RF24.update]
-#[pyclass(frozen, get_all, module = "rf24_py")]
+#[pyclass(frozen, get_all, module = "rf24_py", from_py_object)]
 #[derive(Default, Clone)]
 pub struct StatusFlags {
     /// A flag to describe if RX Data Ready to read.
@@ -78,7 +78,7 @@ impl StatusFlags {
 ///         | nRF24L01 | Si24R1 with<br>LNA Enabled | Si24R1 with<br>LNA Disabled |
 ///         | :-------:|:--------------------------:|:---------------------------:|
 ///         | 0 dBm | 7 dBm | 4 dBm |
-#[pyclass(eq, eq_int, module = "rf24_py")]
+#[pyclass(eq, eq_int, module = "rf24_py", from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PaLevel {
     Min,
@@ -112,7 +112,7 @@ impl PaLevel {
 ///     Mbps1: Represents 1 Mbps
 ///     Mbps2: Represents 2 Mbps
 ///     Kbps250: Represents 250 Kbps
-#[pyclass(eq, eq_int, module = "rf24_py")]
+#[pyclass(eq, eq_int, module = "rf24_py", from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DataRate {
     Mbps1,
@@ -145,7 +145,7 @@ impl DataRate {
 ///     Disabled: Represents no CRC checksum is used.
 ///     Bit8: Represents CRC 8 bit checksum is used.
 ///     Bit16: Represents CRC 16 bit checksum is used.
-#[pyclass(name = "CrcLength", eq, eq_int, module = "rf24_py")]
+#[pyclass(name = "CrcLength", eq, eq_int, module = "rf24_py", from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum CrcLength {
     Disabled,
@@ -179,7 +179,7 @@ impl CrcLength {
 ///     Full: Represent the state of a FIFO when it is full.
 ///     Empty: Represent the state of a FIFO when it is empty.
 ///     Occupied: Represent the state of a FIFO when it is not full but not empty either.
-#[pyclass(eq, eq_int, module = "rf24_py")]
+#[pyclass(eq, eq_int, module = "rf24_py", from_py_object)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum FifoState {
     Full,

--- a/crates/rf24-rs/Cargo.toml
+++ b/crates/rf24-rs/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 exclude = [".github/", "codecov.yml", "docs", "examples"]
 keywords = ["nrf24l01", "wireless", "transceiver", "embedded", "RF24"]
 categories = ["embedded", "no-std"]
-rust-version = "1.65"
+rust-version = "1.68"
 
 [lib]
 name = "rf24"

--- a/crates/rf24-rs/Cargo.toml
+++ b/crates/rf24-rs/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.68"
 name = "rf24"
 
 [dependencies]
-bitfield-struct = "0.9.5"
+bitfield-struct.workspace = true
 defmt = {version = "1.0.1", optional = true}
 embedded-hal = "1.0.0"
 

--- a/crates/rf24ble-rs/Cargo.toml
+++ b/crates/rf24ble-rs/Cargo.toml
@@ -20,7 +20,7 @@ bitfield-struct = "0.9.5"
 embedded-hal = "1.0.0"
 
 [dev-dependencies]
-embedded-hal-mock = "0.11.1"
+embedded-hal-mock = {git = "https://github.com/2bndy5/embedded-hal-mock.git", branch = "dev"}
 
 [features]
 std = []

--- a/crates/rf24ble-rs/Cargo.toml
+++ b/crates/rf24ble-rs/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 exclude = [".github/", "codecov.yml", "docs", "examples"]
 keywords = ["nrf24l01", "wireless", "transceiver", "embedded", "BLE"]
 categories = ["embedded", "no-std"]
-rust-version = "1.65"
+rust-version = "1.68"
 
 [lib]
 name = "rf24ble"

--- a/crates/rf24ble-rs/Cargo.toml
+++ b/crates/rf24ble-rs/Cargo.toml
@@ -16,7 +16,7 @@ name = "rf24ble"
 
 [dependencies]
 rf24-rs = { path = "../rf24-rs", version = "0.3.1" }
-bitfield-struct = "0.9.5"
+bitfield-struct.workspace = true
 embedded-hal = "1.0.0"
 
 [dev-dependencies]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -11,8 +11,8 @@ name = "rf24_rs_examples"
 rf24-rs = {path = "../../crates/rf24-rs", version = "0.3.1"}
 rf24ble-rs = {path = "../../crates/rf24ble-rs", version = "0.1.4"}
 embedded-hal = "1.0.0"
-anyhow = {version = "1.0.98", default-features = false}
-linux-embedded-hal = {version = "0.4.0", optional = true, default-features = false, features = ["gpio_cdev", "spi"]}
+anyhow = {version = "1.0.100", default-features = false}
+linux-embedded-hal = {version = "0.4.1", optional = true, default-features = false, features = ["gpio_cdev", "spi"]}
 
 [features]
 default = ["linux"]

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -12,7 +12,7 @@ rf24-rs = {path = "../../crates/rf24-rs", version = "0.3.1"}
 rf24ble-rs = {path = "../../crates/rf24ble-rs", version = "0.1.4"}
 embedded-hal = "1.0.0"
 anyhow = {version = "1.0.100", default-features = false}
-linux-embedded-hal = {version = "0.4.1", optional = true, default-features = false, features = ["gpio_cdev", "spi"]}
+linux-embedded-hal = {workspace = true, optional = true, default-features = false, features = ["gpio_cdev", "spi"]}
 
 [features]
 default = ["linux"]


### PR DESCRIPTION
also satisfy linter warning about unused code in python binding for non-Linux targets.